### PR TITLE
Refactor script execution

### DIFF
--- a/notebook/codeCellScripts/user_script.js
+++ b/notebook/codeCellScripts/user_script.js
@@ -1,1 +1,3 @@
-console.log("SCRIPT")
+
+console.log('DELIMIT')
+aerservwer

--- a/notebook/codeCellScripts/user_script.js
+++ b/notebook/codeCellScripts/user_script.js
@@ -1,3 +1,5 @@
-
+console.log("serv")
 console.log('DELIMIT')
-aerservwer
+console.log("ERTER");
+            
+[1, 2, 3];

--- a/notebook/codeCellScripts/user_script.js
+++ b/notebook/codeCellScripts/user_script.js
@@ -1,0 +1,1 @@
+console.log("SCRIPT")

--- a/notebook/libs/modules/repl.js
+++ b/notebook/libs/modules/repl.js
@@ -4,84 +4,7 @@ const stripAnsi = require("strip-ansi");
 const repl = {
   execute: (codeString, resultObj, lang) => {
     console.log("BEFORE REPL EXECUTE");
-    const pty = require("node-pty");
-    const stripAnsi = require("strip-ansi");
 
-    const repl = {
-      execute: (codeString, resultObj, lang) => {
-        console.log("BEFORE REPL EXECUTE");
-
-        let replExitMessage;
-        let replType;
-
-        switch (lang) {
-          case "RUBY":
-            replExitMessage = "exit\r";
-            replType = "irb";
-            break;
-          case "JAVASCRIPT":
-            replExitMessage = ".exit\r";
-            replType = "node";
-            break;
-        }
-
-        return new Promise(resolve => {
-          const node = pty.spawn(replType);
-          node.onData(data => (resultObj.result += stripAnsi(data)));
-          node.write(codeString + replExitMessage);
-          node.on("exit", () => {
-            if (resultObj.result) {
-              console.log("AFTER REPL EXECUTE");
-              resolve();
-            }
-          });
-        });
-      },
-      parseOutput: (resultObj, lang) => {
-        switch (lang) {
-          case "RUBY":
-            parseRubyOutput(resultObj);
-            break;
-          case "JAVASCRIPT":
-            parseJSOutput(resultObj);
-            break;
-        }
-      }
-    };
-
-    const parseRubyOutput = resultObj => {
-      return new Promise(resolve => {
-        const byOutput = resultObj.result.split("=>");
-        const dirtyReturnValue = byOutput[byOutput.length - 1];
-        const indexCleanStops = dirtyReturnValue.indexOf("2.4.1"); // fix hard-coding?
-        const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
-        resolve((resultObj.return = cleanReturnValue));
-      });
-    };
-
-    const parseJSOutput = resultObj => {
-      return new Promise((resolve, reject) => {
-        const byOutput = resultObj.result.split(">");
-        const dirtyReturnValue = byOutput[byOutput.length - 2];
-        const cleanReturnValue = extractCleanJSReturnValue(dirtyReturnValue);
-
-        resolve((resultObj.return = cleanReturnValue));
-      });
-    };
-
-    const extractCleanJSReturnValue = string => {
-      const newlines = [...string.matchAll(/\n/g)];
-
-      // if there was only one line of output from the last line of code executed
-      if (newlines.length == 2) {
-        return string.slice(newlines[0].index + 1);
-        // if multiple lines of output were produced by the final line
-      } else {
-        return string.slice(newlines[newlines.length - 2].index + 1);
-      }
-    };
-
-    module.exports = repl;
     let replExitMessage;
     let replType;
 
@@ -94,64 +17,80 @@ const repl = {
         replExitMessage = ".exit\r";
         replType = "node";
         break;
-      case "PYTHON":
-        replExitMessage = "exit()\r";
-        replType = "python";
-        break;
     }
+    const lastCellIdx = Object.keys(resultObj).length - 1;
 
     return new Promise(resolve => {
-      const repl = pty.spawn(replType);
-      repl.onData(data => (resultObj.result += stripAnsi(data)));
-      console.log(resultObj.result);
-      repl.write(codeString + replExitMessage);
-      repl.on("exit", () => {
-        if (resultObj.result) {
-          console.log("AFTER REPL EXECUTE");
-          resolve();
-        }
+      const node = pty.spawn(replType);
+      let returnData = "";
+      node.onData(data => (returnData += stripAnsi(data)));
+      node.write(codeString + replExitMessage);
+      node.on("exit", () => {
+        // assumes REPL is finished, and data is captured, and written to returnData
+        resultObj[lastCellIdx].replOutput = returnData;
+        console.log("AFTER REPL EXECUTE");
+        resolve(resultObj);
       });
     });
   },
   parseOutput: (resultObj, lang) => {
+    const lastCellIdx = Object.keys(resultObj).length - 1;
     switch (lang) {
       case "RUBY":
-        repl.parseRubyOutput(resultObj);
+        return parseRubyOutput(resultObj, lastCellIdx);
         break;
       case "JAVASCRIPT":
-        repl.parseJSOutput(resultObj);
+        return parseJSOutput(resultObj, lastCellIdx);
         break;
       case "PYTHON":
-        repl.parsePythonOutput(resultObj);
+        return parsePythonOutput(resultObj, lastCellIdx);
         break;
     }
-  },
-  parseRubyOutput: resultObj => {
-    return new Promise(resolve => {
-      const byOutput = resultObj.result.split("=>");
-      const dirtyReturnValue = byOutput[byOutput.length - 1];
-      const indexCleanStops = dirtyReturnValue.indexOf("2.4.1"); // fix hard-coding?
-      const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
-      resolve((resultObj.return = cleanReturnValue));
-    });
-  },
-  parseJSOutput: resultObj => {
-    return new Promise(resolve => {
-      const byOutput = resultObj.result.split(">");
-      const dirtyReturnValue = byOutput[byOutput.length - 2];
-      const indexCleanStarts = dirtyReturnValue.indexOf("\n");
-      const cleanReturnValue = dirtyReturnValue.slice(indexCleanStarts);
-      resolve((resultObj.return = cleanReturnValue));
-    });
-  },
-  parsePythonOutput: resultObj => {
-    return new Promise(resolve => {
-      const byOutput = resultObj.result.split(">>>");
-      const dirtyReturnValue = byOutput[byOutput.length - 2];
-      const indexCleanStarts = dirtyReturnValue.indexOf("\n");
-      const cleanReturnValue = dirtyReturnValue.slice(indexCleanStarts);
-      resolve((resultObj.return = cleanReturnValue));
-    });
+  }
+};
+
+const parseRubyOutput = (resultObj, lastIdx) => {
+  return new Promise(resolve => {
+    const byOutput = resultObj[lastIdx].replOutput.split("=>");
+    const dirtyReturnValue = byOutput[byOutput.length - 1];
+    const indexCleanStops = dirtyReturnValue.indexOf("2.4.1"); // fix hard-coding?
+    const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
+    resultObj[lastIdx].return = cleanReturnValue;
+    resolve(resultObj);
+  });
+};
+
+const parseJSOutput = (resultObj, lastIdx) => {
+  return new Promise((resolve, reject) => {
+    const byOutput = resultObj[lastIdx].replOutput.split(">");
+    const dirtyReturnValue = byOutput[byOutput.length - 2];
+    const cleanReturnValue = extractCleanJSReturnValue(dirtyReturnValue);
+    // debugger;
+    resultObj[lastIdx].return = cleanReturnValue;
+    resolve(resultObj);
+  });
+};
+
+const parsePythonOutput = (resultObj, lastIdx) => {
+  return new Promise(resolve => {
+    const byOutput = resultObj[lastIdx].result.split(">>>");
+    const dirtyReturnValue = byOutput[byOutput.length - 2];
+    const indexCleanStarts = dirtyReturnValue.indexOf("\n");
+    const cleanReturnValue = dirtyReturnValue.slice(indexCleanStarts);
+    resultObj[lastIdx].return = cleanReturnValue;
+    resolve(resultObj);
+  });
+};
+
+const extractCleanJSReturnValue = string => {
+  const newlines = [...string.matchAll(/\n/g)];
+
+  // if there was only one line of output from the last line of code executed
+  if (newlines.length == 2) {
+    return string.slice(newlines[0].index + 1);
+    // if multiple lines of output were produced by the final line
+  } else {
+    return string.slice(newlines[newlines.length - 2].index + 1);
   }
 };
 

--- a/notebook/libs/modules/repl.js
+++ b/notebook/libs/modules/repl.js
@@ -4,7 +4,84 @@ const stripAnsi = require("strip-ansi");
 const repl = {
   execute: (codeString, resultObj, lang) => {
     console.log("BEFORE REPL EXECUTE");
+    const pty = require("node-pty");
+    const stripAnsi = require("strip-ansi");
 
+    const repl = {
+      execute: (codeString, resultObj, lang) => {
+        console.log("BEFORE REPL EXECUTE");
+
+        let replExitMessage;
+        let replType;
+
+        switch (lang) {
+          case "RUBY":
+            replExitMessage = "exit\r";
+            replType = "irb";
+            break;
+          case "JAVASCRIPT":
+            replExitMessage = ".exit\r";
+            replType = "node";
+            break;
+        }
+
+        return new Promise(resolve => {
+          const node = pty.spawn(replType);
+          node.onData(data => (resultObj.result += stripAnsi(data)));
+          node.write(codeString + replExitMessage);
+          node.on("exit", () => {
+            if (resultObj.result) {
+              console.log("AFTER REPL EXECUTE");
+              resolve();
+            }
+          });
+        });
+      },
+      parseOutput: (resultObj, lang) => {
+        switch (lang) {
+          case "RUBY":
+            parseRubyOutput(resultObj);
+            break;
+          case "JAVASCRIPT":
+            parseJSOutput(resultObj);
+            break;
+        }
+      }
+    };
+
+    const parseRubyOutput = resultObj => {
+      return new Promise(resolve => {
+        const byOutput = resultObj.result.split("=>");
+        const dirtyReturnValue = byOutput[byOutput.length - 1];
+        const indexCleanStops = dirtyReturnValue.indexOf("2.4.1"); // fix hard-coding?
+        const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
+        resolve((resultObj.return = cleanReturnValue));
+      });
+    };
+
+    const parseJSOutput = resultObj => {
+      return new Promise((resolve, reject) => {
+        const byOutput = resultObj.result.split(">");
+        const dirtyReturnValue = byOutput[byOutput.length - 2];
+        const cleanReturnValue = extractCleanJSReturnValue(dirtyReturnValue);
+
+        resolve((resultObj.return = cleanReturnValue));
+      });
+    };
+
+    const extractCleanJSReturnValue = string => {
+      const newlines = [...string.matchAll(/\n/g)];
+
+      // if there was only one line of output from the last line of code executed
+      if (newlines.length == 2) {
+        return string.slice(newlines[0].index + 1);
+        // if multiple lines of output were produced by the final line
+      } else {
+        return string.slice(newlines[newlines.length - 2].index + 1);
+      }
+    };
+
+    module.exports = repl;
     let replExitMessage;
     let replType;
 

--- a/notebook/libs/modules/userScript.js
+++ b/notebook/libs/modules/userScript.js
@@ -6,22 +6,22 @@ const userScript = {
   scriptExecCmd: "",
   execOptions: (execOptions = {
     encoding: "utf8",
-    timeout: 10000,
+    timeout: 5000,
     maxBuffer: 200 * 1024, // this is 1mb, default is 204 kb
     killSignal: "SIGTERM",
     cwd: null,
     env: null
   }),
 
-  execute: (cellIdx, resultObj) => {
+  execute: resultObj => {
     return new Promise((resolve, reject) => {
       console.log("BEFORE EXECUTING SCRIPT");
       // console.log(userScript.execOptions);
       exec(
-        `${this.command} ./codeCellScripts/cell_${cellIdx}${this.fileType}`,
+        `${this.command} ./codeCellScripts/user_script${this.fileType}`,
         userScript.execOptions,
         (error, stdout, stderr) => {
-          resultObj[cellIdx] = { error, stderr, stdout };
+          resultObj.script = { error, stderr, stdout };
 
           if (error || stderr) {
             console.log("ERROR EXECUTING SCRIPT");
@@ -34,7 +34,6 @@ const userScript = {
       );
     });
   },
-
   writeFile: (codeString, lang) => {
     return new Promise((resolve, reject) => {
       console.log("BEFORE WRITING SCRIPT");
@@ -55,8 +54,6 @@ const userScript = {
         codeString,
         error => {
           if (error) {
-            debugger;
-
             console.log("ERROR WRITING SCRIPT");
             reject(error);
           } else {
@@ -66,6 +63,18 @@ const userScript = {
         }
       );
     });
+  },
+  parseOutput: resultObj => {
+    const stdout = resultObj.script.stdout;
+    const splitOutput = stdout.split("DELIMIT\n");
+    // ['sergwe\nservrew\nerge\n', 'ewt\nwevrr\n', 'erbrbrtb\n']
+    const outputByCell = splitOutput.reduce((outputObj, currentCell, idx) => {
+      outputObj[idx] = currentCell.split("\n");
+      outputObj[idx].pop();
+      return outputObj;
+    }, {});
+
+    resultObj.cellsOutput = outputByCell;
   }
 };
 

--- a/notebook/libs/modules/userScript.js
+++ b/notebook/libs/modules/userScript.js
@@ -35,7 +35,7 @@ const userScript = {
     });
   },
 
-  writeFile: (cellIdx, codeString, lang) => {
+  writeFile: (codeString, lang) => {
     return new Promise((resolve, reject) => {
       console.log("BEFORE WRITING SCRIPT");
 
@@ -51,11 +51,13 @@ const userScript = {
       }
 
       fs.writeFile(
-        `./codeCellScripts/cell_${cellIdx}${this.fileType}`,
+        `./codeCellScripts/user_script${this.fileType}`,
         codeString,
         error => {
           if (error) {
-            // console.log(error);
+            debugger;
+
+            console.log("ERROR WRITING SCRIPT");
             reject(error);
           } else {
             console.log("AFTER WRITING SCRIPT");

--- a/notebook/public/js/app.js
+++ b/notebook/public/js/app.js
@@ -18,7 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     request.addEventListener("load", () => {
       const resultObj = request.response.resultObj;
-
+      debugger;
       mapStdoutToCell(resultObj); // mutates each stdout in resultObj to an array
       appendCellStderror(resultObj);
       appendCellError(resultObj); // mutates stdout in resultObj for cell with MAXBUFFER error

--- a/notebook/script.js
+++ b/notebook/script.js
@@ -1,4 +1,0 @@
-console.log("boo!");
-const a = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5];
-a;
-    gljkba

--- a/notebook/server.js
+++ b/notebook/server.js
@@ -21,13 +21,8 @@ app.post("/", function(req, res) {
 
   const writeScript = () => {
     const script = codeStringArray.join("console.log('DELIMIT')\n"); // cell delimiter must be language-specific
-    debugger;
-    // str = prevCodeStr + str;
-    // prevCodeStr = str;
-    // return userScript.writeFile(idx, str, "JAVASCRIPT");
+    return userScript.writeFile(script, "JAVASCRIPT");
   };
-
-  writeScript();
 
   // find out if fs allows unlink on every file in a dir
   // const deleteScripts = () => {
@@ -46,16 +41,18 @@ app.post("/", function(req, res) {
     }
   };
 
-  // Promise.all(scriptPromises).then(() => {
-  //   executeCells()
-  //     .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
-  //     .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
-  //     .then(() => respondToServer())
-  //     .catch(err => {
-  //       respondToServer();
-  //       console.log(err);
-  //     });
-  // });
+  writeScript()
+    .then(() => {
+      // executeCells()
+      //   .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
+      //   .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
+      //   .then(() => respondToServer())
+      //   .catch(err => {
+      //     respondToServer();
+      //     console.log(err);
+      //   });
+    })
+    .catch(() => {});
 });
 
 app.listen(3000, () => {

--- a/notebook/server.js
+++ b/notebook/server.js
@@ -12,11 +12,10 @@ app.use(bodyParser.json());
 app.post("/", function(req, res) {
   const codeStringArray = req.body.userCode;
   const codeString = codeStringArray.join("");
-  const resultObj = {};
 
-  const respondToClient = () => {
-    userScript.parseOutput(resultObj);
-    res.json({ resultObj });
+  const respondToClient = responseObj => {
+    debugger;
+    res.json({ responseObj });
   };
 
   const writeScript = () => {
@@ -26,13 +25,12 @@ app.post("/", function(req, res) {
 
   writeScript().then(() => {
     userScript
-      .execute(resultObj)
-      .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
-      .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
-      .then(() => respondToClient())
-      .catch(err => {
-        respondToClient();
-        console.log(err);
+      .execute()
+      .then(responseObj => repl.execute(codeString, responseObj, "JAVASCRIPT"))
+      .then(responseObj => repl.parseOutput(responseObj, "JAVASCRIPT"))
+      .then(responseObj => respondToClient(responseObj))
+      .catch(responseObj => {
+        respondToClient(responseObj);
       });
   });
 });

--- a/notebook/server.js
+++ b/notebook/server.js
@@ -19,11 +19,15 @@ app.post("/", function(req, res) {
     res.json({ resultObj });
   };
 
-  const scriptPromises = codeStringArray.map((str, idx) => {
-    str = prevCodeStr + str;
-    prevCodeStr = str;
-    return userScript.writeFile(idx, str, "JAVASCRIPT");
-  });
+  const writeScript = () => {
+    const script = codeStringArray.join("console.log('DELIMIT')\n"); // cell delimiter must be language-specific
+    debugger;
+    // str = prevCodeStr + str;
+    // prevCodeStr = str;
+    // return userScript.writeFile(idx, str, "JAVASCRIPT");
+  };
+
+  writeScript();
 
   // find out if fs allows unlink on every file in a dir
   // const deleteScripts = () => {
@@ -42,16 +46,16 @@ app.post("/", function(req, res) {
     }
   };
 
-  Promise.all(scriptPromises).then(() => {
-    executeCells()
-      .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
-      .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
-      .then(() => respondToServer())
-      .catch(err => {
-        respondToServer();
-        console.log(err);
-      });
-  });
+  // Promise.all(scriptPromises).then(() => {
+  //   executeCells()
+  //     .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
+  //     .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
+  //     .then(() => respondToServer())
+  //     .catch(err => {
+  //       respondToServer();
+  //       console.log(err);
+  //     });
+  // });
 });
 
 app.listen(3000, () => {

--- a/notebook/server.js
+++ b/notebook/server.js
@@ -13,9 +13,9 @@ app.post("/", function(req, res) {
   const codeStringArray = req.body.userCode;
   const codeString = codeStringArray.join("");
   const resultObj = {};
-  let prevCodeStr = "";
 
-  const respondToServer = () => {
+  const respondToClient = () => {
+    userScript.parseOutput(resultObj);
     res.json({ resultObj });
   };
 
@@ -24,35 +24,17 @@ app.post("/", function(req, res) {
     return userScript.writeFile(script, "JAVASCRIPT");
   };
 
-  // find out if fs allows unlink on every file in a dir
-  // const deleteScripts = () => {
-  //   codeStringArray.forEach((_, idx) => {
-  //     fs.unlinkSync(`./codeCellScripts/cell_${idx}${".js"}`); // hard-coded .rb value
-  //   });
-  // };
-
-  const executeCells = async () => {
-    for (let i = 0; i < codeStringArray.length; i++) {
-      try {
-        await userScript.execute(i, resultObj);
-      } catch (err) {
-        throw new Error("Error executing cell.");
-      }
-    }
-  };
-
-  writeScript()
-    .then(() => {
-      // executeCells()
-      //   .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
-      //   .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
-      //   .then(() => respondToServer())
-      //   .catch(err => {
-      //     respondToServer();
-      //     console.log(err);
-      //   });
-    })
-    .catch(() => {});
+  writeScript().then(() => {
+    userScript
+      .execute(resultObj)
+      .then(() => repl.execute(codeString, resultObj, "JAVASCRIPT"))
+      .then(() => repl.parseOutput(resultObj, "JAVASCRIPT"))
+      .then(() => respondToClient())
+      .catch(err => {
+        respondToClient();
+        console.log(err);
+      });
+  });
 });
 
 app.listen(3000, () => {


### PR DESCRIPTION
Introduces the idea of a delimiter to demarcate cells. This allows separation of stdout as well as identifying where errors are thrown. Only executes a single script for all cells. Response Object has been cleaned up for easier client-side use.