### PR TITLE
Exec callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 #ignore codeCellScripts folder
 codeCellScripts
 
+#ignore log files
+*.log
+

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
   </head>
   <body>
     <h1>Javascript</h1>
-    <textarea class="code-cell" id="editor-1">setTimeout(() =>{console.log("there")}, 1000);
-console.log("hi");</textarea>
+    <textarea class="code-cell" id="editor-1">while (true) {
+      console.log("hi");
+    };</textarea>
     <button data-button="0" class="code-submit" id="btn-codecell-1">Run Code</button>
     <h3>Output:</h3>
     <ul id="codecell-0-output" class="code-output"></ul>

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -7,7 +7,7 @@ const userScript = {
   scriptExecCmd: "",
   execOptions: (execOptions = {
     encoding: "utf8",
-    timeout: 10000,
+    timeout: 5000,
     maxBuffer: 200 * 1024, // this is default (204 kb)
     killSignal: "SIGTERM",
     cwd: null,
@@ -16,13 +16,19 @@ const userScript = {
   execute: ws => {
     return new Promise((resolve, reject) => {
       console.log("BEFORE EXECUTING SCRIPT");
-      // console.log(userScript.execOptions);
       const scriptProcess = exec(
         `${this.command} ./codeCellScripts/user_script${this.fileType}`,
-        userScript.execOptions
+        userScript.execOptions,
+        (error, stdout, stderr) => {
+          if (error) {
+            // debugger;
+            ws.send(JSON.stringify({ type: "error", data: error }));
+          }
+        }
       );
 
       scriptProcess.stdout.on("data", data => {
+        // debugger;
         ws.send(JSON.stringify({ type: "stdout", data: data }));
       });
 
@@ -32,7 +38,7 @@ const userScript = {
       });
 
       scriptProcess.stderr.on("data", data => {
-        ws.send(data);
+        debugger;
         reject(JSON.stringify({ type: "stderr", data: data }));
       });
     });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,11 +26,21 @@ document.addEventListener("DOMContentLoaded", () => {
           });
           break;
         case "stderr":
-          const outputUl = document.getElementById(
+          const stderrUl = document.getElementById(
             `codecell-${currentCell}-error`
           );
 
-          appendLi(outputUl, message.data);
+          appendLi(stderrUl, message.data);
+          break;
+        case "error":
+          const errorUl = document.getElementById(
+            `codecell-${currentCell}-error`
+          );
+
+          const signal = message.data.signal;
+          if (signal && signal.match("SIGTERM")) {
+            appendLi(errorUl, "Infinite Loop Error");
+          }
           break;
         case "return":
           const returnUl = document.getElementById(

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ wss.on("connection", ws => {
           ws.send(JSON.stringify({ type: "return", data: returnValue }));
         })
         .catch(data => {
+          debugger;
           ws.send(data);
         });
     });

--- a/yarn-error.log
+++ b/yarn-error.log
@@ -1,0 +1,59 @@
+Arguments: 
+  /usr/local/bin/node /Users/benharvey/.yarn/bin/yarn.js global bin
+
+PATH: 
+  /Users/benharvey/.yarn/bin:/Users/benharvey/.config/yarn/global/node_modules/.bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/benharvey/.rvm/gems/ruby-2.4.1/bin:/Users/benharvey/.rvm/gems/ruby-2.4.1@global/bin:/Users/benharvey/.rvm/rubies/ruby-2.4.1/bin:/Users/benharvey/.yarn/bin:/Users/benharvey/.config/yarn/global/node_modules/.bin:/Users/benharvey/.rvm/bin:/Users/benharvey/.rvm/bin:/Users/benharvey/.rvm/bin:/Users/benharvey/.yarn/bin
+
+Yarn version: 
+  1.17.3
+
+Node version: 
+  12.13.0
+
+Platform: 
+  darwin x64
+
+Trace: 
+  TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
+      at validateString (internal/validators.js:112:11)
+      at Object.isAbsolute (path.js:1030:5)
+      at module.exports.exports.default (/Users/benharvey/.yarn/lib/cli.js:100745:16)
+      at /Users/benharvey/.yarn/lib/cli.js:51488:63
+      at Generator.next (<anonymous>)
+      at step (/Users/benharvey/.yarn/lib/cli.js:304:30)
+      at /Users/benharvey/.yarn/lib/cli.js:315:13
+
+npm manifest: 
+  {
+    "name": "redpoint-testworld",
+    "version": "0.0.1",
+    "private": true,
+    "scripts": {
+      "start": "nodemon --inspect ./server.js --ignore codeCellScripts/"
+    },
+    "dependencies": {
+      "body-parser": "^1.19.0",
+      "codemirror": "^5.49.2",
+      "cookie-parser": "~1.4.4",
+      "debug": "~2.6.9",
+      "express": "~4.16.1",
+      "http-errors": "~1.6.3",
+      "markdown-it": "^10.0.0",
+      "morgan": "^1.9.1",
+      "node-pty": "^0.9.0",
+      "nodemon": "^1.19.4",
+      "nodemonConfig": {
+        "ignore": [
+          "codeCellScripts/"
+        ]
+      },
+      "strip-ansi": "^5.2.0",
+      "ws": "^7.2.0"
+    }
+  }
+
+yarn manifest: 
+  No manifest
+
+Lockfile: 
+  No lockfile


### PR DESCRIPTION
What:
Resets the callback on `exec`, and adds some logic to identify and display SIGTERM errors to the user. Also adds ignoring log files to .gitignore

Why: 
 By switching to the stderr/stdout listeners on the `exec` process (to take advantage of the non-buffered stdout offered by the listener), we lost the ability to catch the SIGTERM and MAXBUFFER errors.  Now the callback emits `error` as type "error", while `stderr` is emitted by the `sterr` listener as type "stderr"

Next: 
The MAXBUFFER error is trickier to catch:  by the time it is issued to the callback, too much stdout has already been emitted to the client.  Possibly we can use some kind of temporary buffer on the client-side, and check if all output in the buffer is identical and greater than a certain length, before appending to the page. 