### PR TITLE
Add buttons 'toolbar' above markdown

### DIFF
--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -1,13 +1,20 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
+import AddCodeCellButton from "../Shared/AddCodeCellButton";
 
 const RenderedMarkdown = props => {
   return (
-    <ReactMarkdown
-      className="rendered-markdown"
-      source={props.code}
-      escapeHtml={true}
-    />
+    <React.Fragment>
+      <AddCodeCellButton
+        onClick={props.onAddCellClick}
+        cellIndex={props.cellIndex}
+      />
+      <ReactMarkdown
+        className="rendered-markdown"
+        source={props.code}
+        escapeHtml={true}
+      />
+    </React.Fragment>
   );
 };
 

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import AddCodeCellButton from "../Shared/AddCodeCellButton";
+import DeleteCellButton from "../Shared/DeleteCellButton";
 
 const RenderedMarkdown = props => {
   return (
@@ -9,6 +10,15 @@ const RenderedMarkdown = props => {
         onClick={props.onAddCellClick}
         cellIndex={props.cellIndex}
       />
+      <div className="code-cell-toolbar">
+        <select>
+          <option>Javascript</option>
+        </select>
+        <DeleteCellButton
+          onClick={props.onDeleteCellClick}
+          cellIndex={props.cellIndex}
+        />
+      </div>
       <ReactMarkdown
         className="rendered-markdown"
         source={props.code}

--- a/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
+++ b/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
@@ -21,6 +21,7 @@ class ToggleableMarkdownContainer extends Component {
       <RenderedMarkdown
         code={this.props.code}
         cellIndex={this.props.cellIndex}
+        onDeleteCellClick={this.props.onDeleteCellClick}
         onAddCellClick={this.props.onAddCellClick}
       />
     );

--- a/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
+++ b/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
@@ -18,7 +18,11 @@ class ToggleableMarkdownContainer extends Component {
         cellIndex={this.props.cellIndex}
       />
     ) : (
-      <RenderedMarkdown code={this.props.code} />
+      <RenderedMarkdown
+        code={this.props.code}
+        cellIndex={this.props.cellIndex}
+        onAddCellClick={this.props.onAddCellClick}
+      />
     );
   }
 }

--- a/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
+++ b/react-redpoint/src/Components/Cells/ToggleableMarkdownContainer.jsx
@@ -8,20 +8,18 @@ class ToggleableMarkdownContainer extends Component {
   };
 
   render() {
-    if (this.state.editable) {
-      return (
-        <CodeCellContainer
-          language={this.props.language}
-          key={this.props.index}
-          code={this.props.code}
-          onDeleteCellClick={this.props.onDeleteCellClick}
-          onAddCellClick={this.props.onAddCellClick}
-          cellIndex={this.props.cellIndex}
-        />
-      );
-    } else {
-      return <RenderedMarkdown code={this.props.code} />;
-    }
+    return this.state.editable ? (
+      <CodeCellContainer
+        language={this.props.language}
+        key={this.props.index}
+        code={this.props.code}
+        onDeleteCellClick={this.props.onDeleteCellClick}
+        onAddCellClick={this.props.onAddCellClick}
+        cellIndex={this.props.cellIndex}
+      />
+    ) : (
+      <RenderedMarkdown code={this.props.code} />
+    );
   }
 }
 


### PR DESCRIPTION
### What:
- Added "toolbar" consisting of delete, select language, and add code cell above the _rendered_ markdown component.

### Why:
- We had only implemented it above code cells, and _editable_ markdown components (a type of code cell).

### Next Steps:
- There's a bit of duplication in rendering the cell "toolbar" in <CodeCell /> and <RenderedMarkdown />. Probably needs its own component.
- Also, it might be worth nesting <RenderedMarkdown /> within <CodeCellContainer />. All 4 of the props we're passing to <RenderedMarkdown /> are also passed to <CodeCellContainer />.