### PR TITLE
Render md cells on blur

### DIFF
--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -18,6 +18,8 @@ class CellsList extends Component {
           cellIndex={index}
           defaultLanguage={this.props.defaultLanguage}
           rendered={cell.rendered}
+          toggleRender={this.props.toggleRender}
+          onUpdateCodeState={this.props.onUpdateCodeState}
         />
       );
     });

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -16,9 +16,10 @@ class CodeCell extends Component {
     this.setState({ code: value });
   };
 
-  handleToggleVisibility = () => {
+  handleBlur = () => {
+    this.props.onUpdateCodeState(this.state.code, this.props.cellIndex);
+
     if (this.props.language === "markdown") {
-      this.props.onUpdateCodeState(this.state.code, this.props.cellIndex);
       this.props.toggleRender(this.props.cellIndex);
     }
   };
@@ -48,7 +49,7 @@ class CodeCell extends Component {
             this.handleChange(value);
           }}
           onChange={(editor, data, value) => {}}
-          onBlur={this.handleToggleVisibility}
+          onBlur={this.handleBlur}
         />
       </div>
     );

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -56,32 +56,3 @@ class CodeCell extends Component {
 }
 
 export default CodeCell;
-
-// class MyComponent extends Component {
-//   handleValueChange = value => this.props.onUpdateValue({ value });
-//   render() {
-//     const { shade } = this.props;
-//     const myOptions = {
-//       mode: "xml",
-//       theme: shade === "dark" ? "material" : "default",
-//       lineNumbers: true
-//     };
-//     return (
-//       <CodeMirror
-//         id="editor"
-//         value={this.props.value}
-//         options={myOptions}
-//         onBeforeChange={(editor, data, value) => {
-//           this.handleValueChange(value);
-//         }}
-//         onChange={(editor, data, value) => {}}
-//       />
-//     );
-//   }
-// }
-
-// function mapStateToProps(state) {
-//   return {
-//     shade: state.muiTheme.shade
-//   };
-// }

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -16,6 +16,13 @@ class CodeCell extends Component {
     this.setState({ code: value });
   };
 
+  handleToggleVisibility = () => {
+    if (this.props.language === "markdown") {
+      this.props.onUpdateCodeState(this.state.code, this.props.cellIndex);
+      this.props.toggleRender(this.props.cellIndex);
+    }
+  };
+
   cellOptions = {
     mode: this.props.language,
     theme: "darcula",
@@ -37,18 +44,11 @@ class CodeCell extends Component {
           value={this.state.code}
           options={this.cellOptions}
           onBeforeChange={(editor, data, value) => {
-            console.log("Editor:", editor);
-            console.log("Data:", data);
-            console.log("Value:", value);
-            console.log("inside onBeforeChange");
+            // console.log("Editor:", editor);
             this.handleChange(value);
           }}
-          onChange={(editor, data, value) => {
-            console.log(editor);
-            console.log(data);
-            console.log(value);
-            console.log("inside onChange");
-          }}
+          onChange={(editor, data, value) => {}}
+          onBlur={this.handleToggleVisibility}
         />
       </div>
     );

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -15,6 +15,7 @@ class CodeCellContainer extends Component {
         onDeleteCellClick={this.props.onDeleteCellClick}
         onAddCellClick={this.props.onAddCellClick}
         defaultLanguage={this.props.defaultLanguage}
+        onRenderedMarkdownClick={this.props.toggleRender}
       />
     ) : (
       <CodeCell
@@ -25,6 +26,8 @@ class CodeCellContainer extends Component {
         onDeleteCellClick={this.props.onDeleteCellClick}
         cellIndex={this.props.cellIndex}
         defaultLanguage={this.props.defaultLanguage}
+        toggleRender={this.props.toggleRender}
+        onUpdateCodeState={this.props.onUpdateCodeState}
       />
     );
   }

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -16,6 +16,7 @@ const RenderedMarkdown = props => {
         className="rendered-markdown"
         source={props.code}
         escapeHtml={true}
+        onClick={props.onRenderedMarkdownClick}
       />
     </React.Fragment>
   );

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -3,6 +3,10 @@ import ReactMarkdown from "react-markdown";
 import CodeCellToolbar from "../Shared/CodeCellToolbar";
 
 const RenderedMarkdown = props => {
+  const handleRenderedMarkdownClick = () => {
+    props.onRenderedMarkdownClick(props.cellIndex);
+  };
+
   return (
     <React.Fragment>
       <CodeCellToolbar
@@ -12,12 +16,9 @@ const RenderedMarkdown = props => {
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
       />
-      <ReactMarkdown
-        className="rendered-markdown"
-        source={props.code}
-        escapeHtml={true}
-        onClick={props.onRenderedMarkdownClick}
-      />
+      <div onClick={handleRenderedMarkdownClick}>
+        <ReactMarkdown className="rendered-markdown" source={props.code} />
+      </div>
     </React.Fragment>
   );
 };

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -38,7 +38,6 @@ class Notebook extends Component {
   handleAddCellClick = (index, type) => {
     this.setState(prevState => {
       const newCells = [...prevState.cells];
-      console.log("New Cells: ", newCells);
       newCells.splice(index, 0, {
         type: type,
         code: ""

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -47,6 +47,25 @@ class Notebook extends Component {
     });
   };
 
+  handleToggleRender = index => {
+    this.setState(prevState => {
+      const newCells = [...prevState.cells];
+      const cellToToggle = newCells[index];
+      cellToToggle.rendered = !cellToToggle.rendered;
+      return { cells: newCells };
+    });
+  };
+
+  handleUpdateCodeState = (code, index) => {
+    this.setState(prevState => {
+      console.log("Code:", code, "Index:", index);
+      const newCells = [...prevState.cells];
+      const cellToUpdate = newCells[index];
+      cellToUpdate.code = code;
+      return { cells: newCells };
+    });
+  };
+
   render() {
     return (
       <div>
@@ -60,6 +79,8 @@ class Notebook extends Component {
             onAddCellClick={this.handleAddCellClick}
             cells={this.state.cells}
             defaultLanguage={this.state.defaultLanguage}
+            toggleRender={this.handleToggleRender}
+            onUpdateCodeState={this.handleUpdateCodeState}
           />
         </Container>
       </div>

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 // import DropdownButton from "react-bootstrap/DropdownButton";
 import SplitButton from "react-bootstrap/SplitButton";
 import Dropdown from "react-bootstrap/Dropdown";
+import uuidv4 from "uuid";
 
 class AddCodeCellButton extends Component {
   state = {
@@ -24,6 +25,8 @@ class AddCodeCellButton extends Component {
             as="button"
             value={lang}
             onClick={this.handleSetCellType}
+            active={this.state.type === lang ? true : false}
+            key={uuidv4()}
           >
             {lang}
           </Dropdown.Item>

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -17,18 +17,22 @@ class AddCodeCellButton extends Component {
     this.setState({ type: e.target.value });
   };
 
+  capitalize = string => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
   render() {
-    const dropDownItems = ["Markdown", "Javascript", "Ruby", "Python"].map(
-      lang => {
+    const dropDownItems = ["markdown", "javascript", "ruby", "python"].map(
+      language => {
         return (
           <Dropdown.Item
             as="button"
-            value={lang}
+            value={language}
             onClick={this.handleSetCellType}
-            active={this.state.type === lang ? true : false}
+            active={this.state.type === language ? true : false}
             key={uuidv4()}
           >
-            {lang}
+            {this.capitalize(language)}
           </Dropdown.Item>
         );
       }

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -3,9 +3,10 @@ import Navbar from "react-bootstrap/Navbar";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import Nav from "react-bootstrap/Nav";
 import logo from "../../placeholder_logo.svg";
+import uuidv4 from "uuid";
 
 class NavigationBar extends React.Component {
-  setDefaultLanguage = e => {
+  handleSetDefaultLanguage = e => {
     const language = e.target.value;
     this.props.setDefaultLanguage(language);
   };
@@ -21,10 +22,11 @@ class NavigationBar extends React.Component {
           <NavDropdown.Item
             as="button"
             value={language}
-            onClick={this.setDefaultLanguage}
+            onClick={this.handleSetDefaultLanguage}
             active={
               this.props.state.defaultLanguage === { language } ? true : false
             }
+            key={uuidv4()}
           >
             {capitalized(language)}
           </NavDropdown.Item>

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -24,7 +24,7 @@ class NavigationBar extends React.Component {
             value={language}
             onClick={this.handleSetDefaultLanguage}
             active={
-              this.props.state.defaultLanguage === { language } ? true : false
+              this.props.state.defaultLanguage === language ? true : false
             }
             key={uuidv4()}
           >


### PR DESCRIPTION
### What:
- Markdown codemirror cells render on blur
- Click on `div` container wrapping rendered markdown causes state to toggle `rendered` status
  - Which causes the editable codemirror markdown cell to render instead of the rendered markdown
- Before toggling rendering, push the local component state of the edited code up to the parent state in `Notebook` in order to render the updated code (for all code types, not just markdown)
- Removed some old unnecessary comments

### Why:
- Better, more responsive UI

### Next Steps:
- Focus on the newly rendered editable markdown cell when it renders, so that users can type into the cell right away

![image](https://user-images.githubusercontent.com/37784155/68818470-10ac4900-0653-11ea-81cd-e25d67b5dd41.png)
![image](https://user-images.githubusercontent.com/37784155/68818490-16a22a00-0653-11ea-9d40-e4cb55d7314f.png)
