### PR TITLE
Change cell language

### DIFF
--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -18,6 +18,7 @@ class CellsList extends Component {
           cellIndex={index}
           defaultLanguage={this.props.defaultLanguage}
           rendered={cell.rendered}
+          onLanguageChange={this.props.onLanguageChange}
         />
       );
     });

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -32,6 +32,7 @@ class CodeCell extends Component {
           onDeleteClick={this.props.onDeleteCellClick}
           language={this.props.language}
           defaultLanguage={this.props.defaultLanguage}
+          onLanguageChange={this.props.onLanguageChange}
         />
         <CodeMirror
           value={this.state.code}

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -37,17 +37,7 @@ class CodeCell extends Component {
           value={this.state.code}
           options={this.cellOptions}
           onBeforeChange={(editor, data, value) => {
-            console.log("Editor:", editor);
-            console.log("Data:", data);
-            console.log("Value:", value);
-            console.log("inside onBeforeChange");
             this.handleChange(value);
-          }}
-          onChange={(editor, data, value) => {
-            console.log(editor);
-            console.log(data);
-            console.log(value);
-            console.log("inside onChange");
           }}
         />
       </div>

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -25,6 +25,7 @@ class CodeCellContainer extends Component {
         onDeleteCellClick={this.props.onDeleteCellClick}
         cellIndex={this.props.cellIndex}
         defaultLanguage={this.props.defaultLanguage}
+        onLanguageChange={this.props.onLanguageChange}
       />
     );
   }

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -16,6 +16,7 @@ class CodeCellContainer extends Component {
         onAddCellClick={this.props.onAddCellClick}
         defaultLanguage={this.props.defaultLanguage}
         onRenderedMarkdownClick={this.props.toggleRender}
+        onLanguageChange={this.props.onLanguageChange}
       />
     ) : (
       <CodeCell

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -15,6 +15,7 @@ const RenderedMarkdown = props => {
         onDeleteClick={props.onDeleteCellClick}
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
+        onLanguageChange={props.onLanguageChange}
       />
       <div onClick={handleRenderedMarkdownClick}>
         <ReactMarkdown className="rendered-markdown" source={props.code} />

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -59,7 +59,6 @@ class Notebook extends Component {
   };
 
   handleToggleRender = index => {
-    debugger;
     this.setState(prevState => {
       const newCells = [...prevState.cells];
       const cellToToggle = newCells[index];

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -47,6 +47,18 @@ class Notebook extends Component {
     });
   };
 
+  handleLanguageChange = (type, cellIndex) => {
+    this.setState(prevState => {
+      const newCells = [...prevState.cells];
+      const changedCell = newCells[cellIndex];
+      changedCell.type = type;
+      if (type === "markdown") {
+        changedCell.rendered = false;
+      }
+      return { cells: newCells };
+    });
+  };
+
   render() {
     return (
       <div>
@@ -60,6 +72,7 @@ class Notebook extends Component {
             onAddCellClick={this.handleAddCellClick}
             cells={this.state.cells}
             defaultLanguage={this.state.defaultLanguage}
+            onLanguageChange={this.handleLanguageChange}
           />
         </Container>
       </div>

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -54,8 +54,12 @@ class Notebook extends Component {
       if (type === "markdown") {
         changedCell.rendered = false;
       }
+      return { cells: newCells };
+    });
+  };
 
   handleToggleRender = index => {
+    debugger;
     this.setState(prevState => {
       const newCells = [...prevState.cells];
       const cellToToggle = newCells[index];

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 // import DropdownButton from "react-bootstrap/DropdownButton";
 import SplitButton from "react-bootstrap/SplitButton";
 import Dropdown from "react-bootstrap/Dropdown";
+import * as constants from "../../Constants/constants";
 
 class AddCodeCellButton extends Component {
   state = {
@@ -17,19 +18,18 @@ class AddCodeCellButton extends Component {
   };
 
   render() {
-    const dropDownItems = ["Markdown", "Javascript", "Ruby", "Python"].map(
-      lang => {
-        return (
-          <Dropdown.Item
-            as="button"
-            value={lang}
-            onClick={this.handleSetCellType}
-          >
-            {lang}
-          </Dropdown.Item>
-        );
-      }
-    );
+    // const dropDownItems = ["Markdown", "Javascript", "Ruby", "Python"].map(
+    const dropDownItems = constants.LANGUAGES.map(lang => {
+      return (
+        <Dropdown.Item
+          as="button"
+          value={lang}
+          onClick={this.handleSetCellType}
+        >
+          {lang}
+        </Dropdown.Item>
+      );
+    });
     const capitalizedLanguage =
       this.state.type.charAt(0).toUpperCase() + this.state.type.slice(1);
     return (

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-// import DropdownButton from "react-bootstrap/DropdownButton";
 import SplitButton from "react-bootstrap/SplitButton";
 import Dropdown from "react-bootstrap/Dropdown";
 import * as constants from "../../Constants/constants";
@@ -18,7 +17,6 @@ class AddCodeCellButton extends Component {
   };
 
   render() {
-    // const dropDownItems = ["Markdown", "Javascript", "Ruby", "Python"].map(
     const dropDownItems = constants.LANGUAGES.map(lang => {
       return (
         <Dropdown.Item
@@ -30,8 +28,9 @@ class AddCodeCellButton extends Component {
         </Dropdown.Item>
       );
     });
-    const capitalizedLanguage =
-      this.state.type.charAt(0).toUpperCase() + this.state.type.slice(1);
+
+    const capitalizedLanguage = constants.capitalizeLanguage(this.state.type);
+
     return (
       <SplitButton
         className={this.props.soloButton ? "solo-add-cell-btn" : null}

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -17,14 +17,15 @@ class AddCodeCellButton extends Component {
   };
 
   render() {
-    const dropDownItems = constants.LANGUAGES.map(lang => {
+    const dropDownItems = constants.LANGUAGES.map(language => {
       return (
         <Dropdown.Item
           as="button"
-          value={lang}
+          value={language}
+          key={language}
           onClick={this.handleSetCellType}
         >
-          {lang}
+          {language}
         </Dropdown.Item>
       );
     });

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -4,7 +4,6 @@ import Dropdown from "react-bootstrap/Dropdown";
 import * as constants from "../../Constants/constants";
 import uuidv4 from "uuid";
 
-
 class AddCodeCellButton extends Component {
   state = {
     type: this.props.defaultLanguage
@@ -30,8 +29,8 @@ class AddCodeCellButton extends Component {
           value={language}
           key={language}
           onClick={this.handleSetCellType}
-          active={this.state.type === language ? true : false}
-            key={uuidv4()}
+          active={this.state.type === language.toLowerCase() ? true : false}
+          key={uuidv4()}
         >
           {language}
         </Dropdown.Item>
@@ -39,7 +38,7 @@ class AddCodeCellButton extends Component {
     });
 
     const capitalizedLanguage = constants.capitalizeLanguage(this.state.type);
-    
+
     return (
       <SplitButton
         className={this.props.soloButton ? "solo-add-cell-btn" : null}

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -14,7 +14,7 @@ class AddCodeCellButton extends Component {
   };
 
   handleSetCellType = e => {
-    this.setState({ type: e.target.value });
+    this.setState({ type: e.target.value.toLowerCase() });
   };
 
   capitalize = string => {

--- a/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
+++ b/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
@@ -7,7 +7,7 @@ const ChangeLanguageDropdown = props => {
   const dropdownItems = constants.LANGUAGES.map(language => {
     return (
       <Dropdown.Item
-        eventKey="markdown"
+        eventKey={language.toLowerCase()}
         key={language}
         active={props.language === language.toLowerCase() ? true : false}
       >
@@ -15,6 +15,10 @@ const ChangeLanguageDropdown = props => {
       </Dropdown.Item>
     );
   });
+
+  const handleLanguageChange = eventKey => {
+    props.onLanguageChange(eventKey, props.cellIndex);
+  };
 
   const capitalizedLanguage = constants.capitalizeLanguage(props.language);
 
@@ -24,9 +28,7 @@ const ChangeLanguageDropdown = props => {
       id="dropdown-basic-button"
       title={capitalizedLanguage}
       size="sm"
-      onSelect={(eventKey, event) => {
-        debugger;
-      }}
+      onSelect={handleLanguageChange}
     >
       {dropdownItems}
     </DropdownButton>

--- a/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
+++ b/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
@@ -1,42 +1,34 @@
 import React from "react";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import Dropdown from "react-bootstrap/Dropdown";
+import * as constants from "../../Constants/constants";
 
 const ChangeLanguageDropdown = props => {
+  const dropdownItems = constants.LANGUAGES.map(language => {
+    return (
+      <Dropdown.Item
+        eventKey="markdown"
+        key={language}
+        active={props.language === language.toLowerCase() ? true : false}
+      >
+        {language}
+      </Dropdown.Item>
+    );
+  });
+
+  const capitalizedLanguage = constants.capitalizeLanguage(props.language);
+
   return (
     <DropdownButton
       variant="secondary"
       id="dropdown-basic-button"
-      title={props.language}
+      title={capitalizedLanguage}
       size="sm"
       onSelect={(eventKey, event) => {
         debugger;
       }}
     >
-      <Dropdown.Item
-        eventKey="markdown"
-        active={props.language === "markdown" ? true : false}
-      >
-        Markdown
-      </Dropdown.Item>
-      <Dropdown.Item
-        eventKey="javascript"
-        active={props.language === "javascript" ? true : false}
-      >
-        Javascript
-      </Dropdown.Item>
-      <Dropdown.Item
-        eventKey="ruby"
-        active={props.language === "ruby" ? true : false}
-      >
-        Ruby
-      </Dropdown.Item>
-      <Dropdown.Item
-        eventKey="python"
-        active={props.language === "python" ? true : false}
-      >
-        Python
-      </Dropdown.Item>
+      {dropdownItems}
     </DropdownButton>
   );
 };

--- a/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
+++ b/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
@@ -9,30 +9,30 @@ const ChangeLanguageDropdown = props => {
       id="dropdown-basic-button"
       title={props.language}
       size="sm"
-      onSelect={e => {
+      onSelect={(eventKey, event) => {
         debugger;
       }}
     >
       <Dropdown.Item
-        href="#/action-1"
+        eventKey="markdown"
         active={props.language === "markdown" ? true : false}
       >
         Markdown
       </Dropdown.Item>
       <Dropdown.Item
-        href="#/action-2"
+        eventKey="javascript"
         active={props.language === "javascript" ? true : false}
       >
         Javascript
       </Dropdown.Item>
       <Dropdown.Item
-        href="#/action-3"
+        eventKey="ruby"
         active={props.language === "ruby" ? true : false}
       >
         Ruby
       </Dropdown.Item>
       <Dropdown.Item
-        href="#/action-4"
+        eventKey="python"
         active={props.language === "python" ? true : false}
       >
         Python

--- a/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
+++ b/react-redpoint/src/Components/Shared/ChangeLanguageDropdown.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import DropdownButton from "react-bootstrap/DropdownButton";
+import Dropdown from "react-bootstrap/Dropdown";
+
+const ChangeLanguageDropdown = props => {
+  return (
+    <DropdownButton
+      variant="secondary"
+      id="dropdown-basic-button"
+      title={props.language}
+      size="sm"
+      onSelect={e => {
+        debugger;
+      }}
+    >
+      <Dropdown.Item
+        href="#/action-1"
+        active={props.language === "markdown" ? true : false}
+      >
+        Markdown
+      </Dropdown.Item>
+      <Dropdown.Item
+        href="#/action-2"
+        active={props.language === "javascript" ? true : false}
+      >
+        Javascript
+      </Dropdown.Item>
+      <Dropdown.Item
+        href="#/action-3"
+        active={props.language === "ruby" ? true : false}
+      >
+        Ruby
+      </Dropdown.Item>
+      <Dropdown.Item
+        href="#/action-4"
+        active={props.language === "python" ? true : false}
+      >
+        Python
+      </Dropdown.Item>
+    </DropdownButton>
+  );
+};
+
+export default ChangeLanguageDropdown;

--- a/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
@@ -8,6 +8,8 @@ const CodeCellToolbar = props => {
     <div className="code-cell-toolbar">
       <ChangeLanguageDropdown
         language={props.language}
+        onLanguageChange={props.onLanguageChange}
+        cellIndex={props.cellIndex}
       ></ChangeLanguageDropdown>
       <AddCodeCellButton
         onClick={props.onAddClick}

--- a/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
@@ -1,47 +1,14 @@
 import React from "react";
 import AddCodeCellButton from "../Shared/AddCodeCellButton";
 import DeleteCellButton from "./DeleteCellButton";
-import DropdownButton from "react-bootstrap/DropdownButton";
-import Dropdown from "react-bootstrap/Dropdown";
+import ChangeLanguageDropdown from "./ChangeLanguageDropdown";
 
 const CodeCellToolbar = props => {
-  // const handleAddCellClick = () => {
-  //   props.onAddClick(props.cellIndex);
-  // };
-
   return (
     <div className="code-cell-toolbar">
-      <DropdownButton
-        variant="secondary"
-        id="dropdown-basic-button"
-        title={props.language}
-        size="sm"
-      >
-        <Dropdown.Item
-          href="#/action-1"
-          active={props.language === "markdown" ? true : false}
-        >
-          Markdown
-        </Dropdown.Item>
-        <Dropdown.Item
-          href="#/action-2"
-          active={props.language === "javascript" ? true : false}
-        >
-          Javascript
-        </Dropdown.Item>
-        <Dropdown.Item
-          href="#/action-3"
-          active={props.language === "ruby" ? true : false}
-        >
-          Ruby
-        </Dropdown.Item>
-        <Dropdown.Item
-          href="#/action-4"
-          active={props.language === "python" ? true : false}
-        >
-          Python
-        </Dropdown.Item>
-      </DropdownButton>
+      <ChangeLanguageDropdown
+        language={props.language}
+      ></ChangeLanguageDropdown>
       <AddCodeCellButton
         onClick={props.onAddClick}
         cellIndex={props.cellIndex}

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -3,6 +3,7 @@ import Navbar from "react-bootstrap/Navbar";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import Nav from "react-bootstrap/Nav";
 import logo from "../../placeholder_logo.svg";
+import * as constants from "../../Constants/constants";
 
 class NavigationBar extends React.Component {
   setDefaultLanguage = e => {
@@ -11,26 +12,21 @@ class NavigationBar extends React.Component {
   };
 
   render() {
-    const capitalized = string => {
-      return string.charAt(0).toUpperCase() + string.slice(1);
-    };
-    // TODO: pull language options from a config file
-    const navDropDownItems = ["markdown", "javascript", "ruby", "python"].map(
-      language => {
-        return (
-          <NavDropdown.Item
-            as="button"
-            value={language}
-            onClick={this.setDefaultLanguage}
-            active={
-              this.props.state.defaultLanguage === { language } ? true : false
-            }
-          >
-            {capitalized(language)}
-          </NavDropdown.Item>
-        );
-      }
-    );
+    const navDropDownItems = constants.LOWERCASE_LANGUAGES.map(language => {
+      return (
+        <NavDropdown.Item
+          as="button"
+          key={language}
+          value={language}
+          onClick={this.setDefaultLanguage}
+          active={
+            this.props.state.defaultLanguage === { language } ? true : false
+          }
+        >
+          {constants.capitalizeLanguage(language)}
+        </NavDropdown.Item>
+      );
+    });
 
     return (
       <Navbar bg="dark" variant="dark">

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -20,9 +20,7 @@ class NavigationBar extends React.Component {
           key={uuidv4()}
           value={language}
           onClick={this.handleSetDefaultLanguage}
-          active={
-            this.props.state.defaultLanguage === { language } ? true : false
-          }
+          active={this.props.state.defaultLanguage === language ? true : false}
         >
           {constants.capitalizeLanguage(language)}
         </NavDropdown.Item>

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -6,7 +6,6 @@ import logo from "../../placeholder_logo.svg";
 import * as constants from "../../Constants/constants";
 import uuidv4 from "uuid";
 
-
 class NavigationBar extends React.Component {
   handleSetDefaultLanguage = e => {
     const language = e.target.value;
@@ -18,9 +17,9 @@ class NavigationBar extends React.Component {
       return (
         <NavDropdown.Item
           as="button"
-           key={uuidv4()}
+          key={uuidv4()}
           value={language}
-          onClick={this.setDefaultLanguage}
+          onClick={this.handleSetDefaultLanguage}
           active={
             this.props.state.defaultLanguage === { language } ? true : false
           }

--- a/react-redpoint/src/Constants/constants.js
+++ b/react-redpoint/src/Constants/constants.js
@@ -1,0 +1,1 @@
+export const LANGUAGES = ["Markdown", "Javascript", "Ruby", "Python"];

--- a/react-redpoint/src/Constants/constants.js
+++ b/react-redpoint/src/Constants/constants.js
@@ -1,3 +1,4 @@
 export const LANGUAGES = ["Markdown", "Javascript", "Ruby", "Python"];
+export const LOWERCASE_LANGUAGES = ["markdown", "javascript", "ruby", "python"];
 export const capitalizeLanguage = language =>
   language.charAt(0).toUpperCase() + language.slice(1);

--- a/react-redpoint/src/Constants/constants.js
+++ b/react-redpoint/src/Constants/constants.js
@@ -1,1 +1,3 @@
 export const LANGUAGES = ["Markdown", "Javascript", "Ruby", "Python"];
+export const capitalizeLanguage = language =>
+  language.charAt(0).toUpperCase() + language.slice(1);


### PR DESCRIPTION
What: 
Adds a ChangeLanguageDropdown component. On select, changes the cell in cells state to the selected language type. Sets rendered: false if markdown cell is selected. Adds a Constants folder with language constants in constants.js

Why:
Add feature for changing the language of a cell

Next Steps:
Seems like standardizing the capitalization of language names in Notebook state would save a lot of upcase/downcase/capitalization across the app.
