### PR TITLE
Cell toolbar position

### DIFF
--- a/react-redpoint/src/App.css
+++ b/react-redpoint/src/App.css
@@ -28,14 +28,34 @@
   text-align: left;
 }
 
-.code-cell-toolbar {
+.cell-toolbar,
+.cell-toolbar-markdown {
   width: 900px;
   display: flex;
   justify-content: space-between;
-  margin: 25px 0 25px 0;
+  margin: 25px 0 0 0;
+  background: #2b2b29;
+  /* border-bottom: 1px solid #6c757e; */
+}
+
+.cell-toolbar-markdown {
+  background: #474b56;
+  margin-bottom: 20px;
+}
+
+.btn-secondary {
+  font-size: 25px;
+  /* margin: -10px; */
+  /* font-weight: 600; */
 }
 
 /* To set margin on bottom add new cell button */
 .solo-add-cell-btn {
   margin: 25px auto 25px;
+}
+
+div .rendered-markdown {
+  border-top: 1px solid #6b757e;
+  border-bottom: 1px solid #6b757e;
+  padding: 10px 0;
 }

--- a/react-redpoint/src/App.css
+++ b/react-redpoint/src/App.css
@@ -33,9 +33,7 @@
   width: 900px;
   display: flex;
   justify-content: space-between;
-  margin: 25px 0 0 0;
   background: #2b2b29;
-  /* border-bottom: 1px solid #6c757e; */
 }
 
 .cell-toolbar-markdown {
@@ -44,18 +42,18 @@
 }
 
 .btn-secondary {
-  font-size: 25px;
+  /* font-size: 25px; */
   /* margin: -10px; */
   /* font-weight: 600; */
 }
 
 /* To set margin on bottom add new cell button */
-.solo-add-cell-btn {
+.add-cell-btn {
   margin: 25px auto 25px;
 }
 
 div .rendered-markdown {
   border-top: 1px solid #6b757e;
   border-bottom: 1px solid #6b757e;
-  padding: 10px 0;
+  padding-top: 10px;
 }

--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import AddCodeCellButton from "../Shared/AddCodeCellButton";
+import AddCellButton from "../Shared/AddCellButton";
 import CodeCellContainer from "./CodeCellContainer";
 import uuidv4 from "uuid/v4";
 
@@ -26,7 +26,7 @@ class CellsList extends Component {
     });
 
     cellContainers.push(
-      <AddCodeCellButton
+      <AddCellButton
         soloButton="true"
         cellIndex={cellContainers.length}
         onClick={this.props.onAddCellClick}

--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -28,7 +28,6 @@ class CellsList extends Component {
     cellContainers.push(
       <AddCodeCellButton
         soloButton="true"
-        // className="solo-add-code-cell-btn" // TODO: not being applied
         cellIndex={cellContainers.length}
         onClick={this.props.onAddCellClick}
         key={uuidv4()}

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
-import CodeCellToolbar from "../Shared/CodeCellToolbar";
+import CellToolbar from "../Shared/CellToolbar";
+import AddCodeCellButton from "../Shared/AddCodeCellButton";
 import "codemirror/lib/codemirror.css";
 import "codemirror/theme/darcula.css";
 import "codemirror/mode/javascript/javascript.js";
@@ -34,13 +35,20 @@ class CodeCell extends Component {
   render() {
     return (
       <div>
-        <CodeCellToolbar
+        <AddCodeCellButton
+          className="add-cell-btn"
+          onClick={this.props.onAddClick}
+          cellIndex={this.props.cellIndex}
+          defaultLanguage={this.props.defaultLanguage}
+        />
+        <CellToolbar
           onAddClick={this.props.onAddCellClick}
           cellIndex={this.props.cellIndex}
           onDeleteClick={this.props.onDeleteCellClick}
           language={this.props.language}
           defaultLanguage={this.props.defaultLanguage}
           onLanguageChange={this.props.onLanguageChange}
+          rendered={this.props.rendered}
         />
         <CodeMirror
           value={this.state.code}

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import CellToolbar from "../Shared/CellToolbar";
-import AddCodeCellButton from "../Shared/AddCodeCellButton";
+import AddCellButton from "../Shared/AddCellButton";
 import "codemirror/lib/codemirror.css";
 import "codemirror/theme/darcula.css";
 import "codemirror/mode/javascript/javascript.js";
@@ -35,7 +35,7 @@ class CodeCell extends Component {
   render() {
     return (
       <div>
-        <AddCodeCellButton
+        <AddCellButton
           className="add-cell-btn"
           onClick={this.props.onAddClick}
           cellIndex={this.props.cellIndex}

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -17,6 +17,7 @@ class CodeCellContainer extends Component {
         defaultLanguage={this.props.defaultLanguage}
         onRenderedMarkdownClick={this.props.toggleRender}
         onLanguageChange={this.props.onLanguageChange}
+        rendered={this.props.rendered}
       />
     ) : (
       <CodeCell
@@ -30,6 +31,7 @@ class CodeCellContainer extends Component {
         onLanguageChange={this.props.onLanguageChange}
         toggleRender={this.props.toggleRender}
         onUpdateCodeState={this.props.onUpdateCodeState}
+        rendered={this.props.rendered}
       />
     );
   }

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import CellToolbar from "../Shared/CellToolbar";
-import AddCodeCellButton from "../Shared/AddCodeCellButton";
+import AddCellButton from "../Shared/AddCellButton";
 
 const RenderedMarkdown = props => {
   const handleRenderedMarkdownClick = () => {
@@ -10,7 +10,7 @@ const RenderedMarkdown = props => {
 
   return (
     <React.Fragment>
-      <AddCodeCellButton
+      <AddCellButton
         onClick={props.onAddClick}
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
@@ -24,8 +24,8 @@ const RenderedMarkdown = props => {
         onLanguageChange={props.onLanguageChange}
         rendered={props.rendered}
       />
-      <div onClick={handleRenderedMarkdownClick}>
-        <ReactMarkdown className="rendered-markdown" source={props.code} />
+      <div onClick={handleRenderedMarkdownClick} className="rendered-markdown">
+        <ReactMarkdown source={props.code} />
       </div>
     </React.Fragment>
   );

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import CodeCellToolbar from "../Shared/CodeCellToolbar";
+import CellToolbar from "../Shared/CellToolbar";
+import AddCodeCellButton from "../Shared/AddCodeCellButton";
 
 const RenderedMarkdown = props => {
   const handleRenderedMarkdownClick = () => {
@@ -9,13 +10,19 @@ const RenderedMarkdown = props => {
 
   return (
     <React.Fragment>
-      <CodeCellToolbar
+      <AddCodeCellButton
+        onClick={props.onAddClick}
+        cellIndex={props.cellIndex}
+        defaultLanguage={props.defaultLanguage}
+      />
+      <CellToolbar
         language={props.language}
         onAddClick={props.onAddCellClick}
         onDeleteClick={props.onDeleteCellClick}
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
         onLanguageChange={props.onLanguageChange}
+        rendered={props.rendered}
       />
       <div onClick={handleRenderedMarkdownClick}>
         <ReactMarkdown className="rendered-markdown" source={props.code} />

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -69,7 +69,6 @@ class Notebook extends Component {
 
   handleUpdateCodeState = (code, index) => {
     this.setState(prevState => {
-      console.log("Code:", code, "Index:", index);
       const newCells = [...prevState.cells];
       const cellToUpdate = newCells[index];
       cellToUpdate.code = code;

--- a/react-redpoint/src/Components/Shared/AddCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCellButton.jsx
@@ -3,7 +3,7 @@ import SplitButton from "react-bootstrap/SplitButton";
 import Dropdown from "react-bootstrap/Dropdown";
 import * as constants from "../../Constants/constants";
 
-class AddCodeCellButton extends Component {
+class AddCellButton extends Component {
   state = {
     type: this.props.defaultLanguage
   };
@@ -39,7 +39,7 @@ class AddCodeCellButton extends Component {
 
     return (
       <SplitButton
-        className="solo-add-cell-btn"
+        className="add-cell-btn"
         variant="secondary"
         id="dropdown-basic-button"
         title={`Add ${capitalizedLanguage} Cell`}
@@ -52,4 +52,4 @@ class AddCodeCellButton extends Component {
   }
 }
 
-export default AddCodeCellButton;
+export default AddCellButton;

--- a/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/AddCodeCellButton.jsx
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import SplitButton from "react-bootstrap/SplitButton";
 import Dropdown from "react-bootstrap/Dropdown";
 import * as constants from "../../Constants/constants";
-import uuidv4 from "uuid";
 
 class AddCodeCellButton extends Component {
   state = {
@@ -30,7 +29,6 @@ class AddCodeCellButton extends Component {
           key={language}
           onClick={this.handleSetCellType}
           active={this.state.type === language.toLowerCase() ? true : false}
-          key={uuidv4()}
         >
           {language}
         </Dropdown.Item>
@@ -41,7 +39,7 @@ class AddCodeCellButton extends Component {
 
     return (
       <SplitButton
-        className={this.props.soloButton ? "solo-add-cell-btn" : null}
+        className="solo-add-cell-btn"
         variant="secondary"
         id="dropdown-basic-button"
         title={`Add ${capitalizedLanguage} Cell`}

--- a/react-redpoint/src/Components/Shared/CellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CellToolbar.jsx
@@ -1,21 +1,21 @@
 import React from "react";
-import AddCodeCellButton from "../Shared/AddCodeCellButton";
 import DeleteCellButton from "./DeleteCellButton";
 import ChangeLanguageDropdown from "./ChangeLanguageDropdown";
 
-const CodeCellToolbar = props => {
+const CellToolbar = props => {
   return (
-    <div className="code-cell-toolbar">
+    <div
+      className={
+        props.language === "markdown" && props.rendered === true
+          ? "cell-toolbar-markdown"
+          : "cell-toolbar"
+      }
+    >
       <ChangeLanguageDropdown
         language={props.language}
         onLanguageChange={props.onLanguageChange}
         cellIndex={props.cellIndex}
       ></ChangeLanguageDropdown>
-      <AddCodeCellButton
-        onClick={props.onAddClick}
-        cellIndex={props.cellIndex}
-        defaultLanguage={props.defaultLanguage}
-      />
       <DeleteCellButton
         onClick={props.onDeleteClick}
         cellIndex={props.cellIndex}
@@ -24,4 +24,4 @@ const CodeCellToolbar = props => {
   );
 };
 
-export default CodeCellToolbar;
+export default CellToolbar;

--- a/react-redpoint/src/Components/Shared/DeleteCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/DeleteCellButton.jsx
@@ -8,7 +8,7 @@ const DeleteCellButton = props => {
 
   return (
     <Button onClick={handleDeleteCellClick} variant="secondary" size="sm">
-      <span>&times; Delete</span>
+      <span className="delete-cell">&times;</span>
     </Button>
   );
 };


### PR DESCRIPTION
### What:
- Styling Fixes:
- Changed "Delete X" button to Just an X
- Removed margin from toolbar and changed background colour to mimic code cells
- Rendered Markdown cell toolbars have correct background color
- Removed AddCodeCellButton from cell toolbar, it belongs in the gap
- Renamed AddCodeCellButton to more generic AddCellButton
- Added horizontal borders to top and bottom of rendered markdown

### Why:
- Better styling
- Add cell button semantically should not belong to a cell

### Next Steps:
- Fix minor codemirror visual bleed in top left corner
- Adjust rounding of button corners against right angle background of codemirror cells

![Screen Shot 2019-11-14 at 11 56 52 AM](https://user-images.githubusercontent.com/37784155/68878545-e8b1f980-06d5-11ea-96bf-5e6bf5b772c2.png)
