### PR TITLE
Fix rendered markdown toolbar background

### DIFF
--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -42,9 +42,8 @@ class CodeCell extends Component {
           defaultLanguage={this.props.defaultLanguage}
         />
         <CellToolbar
-          onAddClick={this.props.onAddCellClick}
           cellIndex={this.props.cellIndex}
-          onDeleteClick={this.props.onDeleteCellClick}
+          onDeleteClick={this.props.onDeleteClick}
           language={this.props.language}
           defaultLanguage={this.props.defaultLanguage}
           onLanguageChange={this.props.onLanguageChange}

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -12,8 +12,8 @@ class CodeCellContainer extends Component {
         language={this.props.language}
         code={this.props.code}
         cellIndex={this.props.cellIndex}
-        onDeleteCellClick={this.props.onDeleteCellClick}
-        onAddCellClick={this.props.onAddCellClick}
+        onDeleteClick={this.props.onDeleteCellClick}
+        onAddClick={this.props.onAddCellClick}
         defaultLanguage={this.props.defaultLanguage}
         onRenderedMarkdownClick={this.props.toggleRender}
         onLanguageChange={this.props.onLanguageChange}
@@ -24,8 +24,8 @@ class CodeCellContainer extends Component {
         language={this.props.language}
         key={this.props.index}
         code={this.props.code}
-        onAddCellClick={this.props.onAddCellClick}
-        onDeleteCellClick={this.props.onDeleteCellClick}
+        onAddClick={this.props.onAddCellClick}
+        onDeleteClick={this.props.onDeleteCellClick}
         cellIndex={this.props.cellIndex}
         defaultLanguage={this.props.defaultLanguage}
         onLanguageChange={this.props.onLanguageChange}

--- a/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
+++ b/react-redpoint/src/Components/Cells/RenderedMarkdown.jsx
@@ -17,8 +17,8 @@ const RenderedMarkdown = props => {
       />
       <CellToolbar
         language={props.language}
-        onAddClick={props.onAddCellClick}
-        onDeleteClick={props.onDeleteCellClick}
+        onAddClick={props.onAddClick}
+        onDeleteClick={props.onDeleteClick}
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
         onLanguageChange={props.onLanguageChange}

--- a/react-redpoint/src/Components/Shared/CellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CellToolbar.jsx
@@ -6,7 +6,7 @@ const CellToolbar = props => {
   return (
     <div
       className={
-        props.language === "markdown" && props.rendered === true
+        props.language === "Markdown" && props.rendered === true
           ? "cell-toolbar-markdown"
           : "cell-toolbar"
       }

--- a/react-redpoint/src/Components/Shared/CellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CellToolbar.jsx
@@ -12,7 +12,7 @@ const CellToolbar = props => {
       }
     >
       <ChangeLanguageDropdown
-        language={props.language}
+        language={`${props.language} Cell`}
         onLanguageChange={props.onLanguageChange}
         cellIndex={props.cellIndex}
       ></ChangeLanguageDropdown>


### PR DESCRIPTION
### What:
- Fixed toolbar background color issue
- Fixed bug with adding cell and not receiving props
- General cleanup of variable naming (removed redundant "code" from names)
- Added "Cell" to dropdown in top-left to make clear that it is changing the language of the cell

### Why:
- Bug fixes
- General cleanup

![Screen Shot 2019-11-14 at 12 35 59 PM](https://user-images.githubusercontent.com/37784155/68881561-5876b300-06db-11ea-8789-808839628da2.png)
