### PR TITLE
Adds run button to non-markdown cells.

### DIFF
--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -21,6 +21,7 @@ class CellsList extends Component {
           onLanguageChange={this.props.onLanguageChange}
           toggleRender={this.props.toggleRender}
           onUpdateCodeState={this.props.onUpdateCodeState}
+          onRunClick={this.props.onRunClick}
         />
       );
     });

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -38,6 +38,7 @@ class CodeCell extends Component {
           onAddClick={this.props.onAddCellClick}
           cellIndex={this.props.cellIndex}
           onDeleteClick={this.props.onDeleteCellClick}
+          onRunClick={this.props.onRunClick}
           language={this.props.language}
           defaultLanguage={this.props.defaultLanguage}
           onLanguageChange={this.props.onLanguageChange}

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -30,6 +30,7 @@ class CodeCellContainer extends Component {
         onLanguageChange={this.props.onLanguageChange}
         toggleRender={this.props.toggleRender}
         onUpdateCodeState={this.props.onUpdateCodeState}
+        onRunClick={this.props.onRunClick}
       />
     );
   }

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -46,6 +46,10 @@ class Notebook extends Component {
     });
   };
 
+  handleRunCellClick = index => {
+    debugger;
+  };
+
   handleLanguageChange = (type, cellIndex) => {
     this.setState(prevState => {
       const newCells = [...prevState.cells];
@@ -93,6 +97,7 @@ class Notebook extends Component {
             onLanguageChange={this.handleLanguageChange}
             toggleRender={this.handleToggleRender}
             onUpdateCodeState={this.handleUpdateCodeState}
+            onRunClick={this.handleRunCellClick}
           />
         </Container>
       </div>

--- a/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
+++ b/react-redpoint/src/Components/Shared/CodeCellToolbar.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import AddCodeCellButton from "../Shared/AddCodeCellButton";
 import DeleteCellButton from "./DeleteCellButton";
+import RunCellButton from "./RunCellButton";
 import ChangeLanguageDropdown from "./ChangeLanguageDropdown";
 
 const CodeCellToolbar = props => {
@@ -16,6 +17,12 @@ const CodeCellToolbar = props => {
         cellIndex={props.cellIndex}
         defaultLanguage={props.defaultLanguage}
       />
+      {props.language !== "Markdown" ? (
+        <RunCellButton
+          onClick={props.onRunClick}
+          cellIndex={props.cellIndex}
+        ></RunCellButton>
+      ) : null}
       <DeleteCellButton
         onClick={props.onDeleteClick}
         cellIndex={props.cellIndex}

--- a/react-redpoint/src/Components/Shared/RunCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/RunCellButton.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Button from "react-bootstrap/Button";
+
+const RunCellButton = props => {
+  const handleRunCellClick = () => {
+    props.onClick(props.cellIndex);
+  };
+
+  return (
+    <Button onClick={handleRunCellClick} variant="secondary" size="sm">
+      <span>&#9658; Run</span>
+    </Button>
+  );
+};
+
+export default RunCellButton;


### PR DESCRIPTION
### What:
Adds a run button for only non-markdown cells.  Drills handleRunCellClick from Notebook.jsx to button, but method is empty for now.
### Why:
Run code cells by clicking button. 
### Next Steps:
Add logic to handleRunCellClick to interact with back end