### PR TITLE
Manage server response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 node_modules
 
 #ignore codeCellScripts folder
-codeCellScripts
+codeCellScripts/*
 
 #ignore log files
 *.log

--- a/libs/modules/repl.js
+++ b/libs/modules/repl.js
@@ -24,6 +24,7 @@ const repl = {
     }
 
     return new Promise(resolve => {
+      console.log(`Repl Command: ${codeString + replExitMessage}`);
       const node = pty.spawn(replType);
       let returnData = "";
       node.onData(data => (returnData += stripAnsi(data)));

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -26,7 +26,6 @@ const userScript = {
       );
 
       scriptProcess.stdout.on("data", data => {
-        debugger;
         if (data === delimiter) {
           ws.send(JSON.stringify({ type: "delimiter" }));
         }

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -26,14 +26,18 @@ const userScript = {
       );
 
       scriptProcess.stdout.on("data", data => {
-        if (data === delimiter) {
-          ws.send(JSON.stringify({ type: "delimiter" }));
-        }
-        ws.send(JSON.stringify({ type: "stdout", data: data }));
+        const dataArray = data.split("\n").slice(0, -1);
+        dataArray.forEach(data => {
+          if (data === delimiter) {
+            ws.send(JSON.stringify({ type: "delimiter" }));
+          } else {
+            ws.send(JSON.stringify({ type: "stdout", data: data }));
+          }
+        });
       });
 
       scriptProcess.stdout.on("end", () => {
-        ws.send(JSON.stringify({ type: "end", data: "Script completed" }));
+        // ws.send(JSON.stringify({ type: "end", data: "Script completed" }));
         resolve();
       });
 

--- a/react-redpoint/src/Components/Cells/CellResults.jsx
+++ b/react-redpoint/src/Components/Cells/CellResults.jsx
@@ -16,7 +16,7 @@ class CellResults extends Component {
         case "return":
           return <Return key={"return"} returnVal={data} />;
         case "error":
-          return <Error key={"error"} cerror={data} />;
+          return <Error key={"error"} error={data} />;
         default:
           return;
       }

--- a/react-redpoint/src/Components/Cells/CodeCell.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCell.jsx
@@ -16,6 +16,7 @@ class CodeCell extends Component {
 
   handleChange = value => {
     this.setState({ code: value });
+    // this.props.onUpdateCodeState(value, this.props.cellIndex);
   };
 
   handleBlur = () => {

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -15,7 +15,7 @@ class Notebook extends Component {
       },
       {
         type: "Javascript",
-        code: "",
+        code: "console.log('hi');\nconsole.log('there');\n",
         results: { output: "", error: "", return: "" }
       }
       // {
@@ -79,7 +79,7 @@ class Notebook extends Component {
           this.setState(prevState => {
             const newCells = [...prevState.cells].map((cell, index) => {
               if (index === cellIndex) {
-                cell.results.output += message.data;
+                cell.results.output += message.data + "\n";
                 return cell;
               } else {
                 return cell;
@@ -122,15 +122,14 @@ class Notebook extends Component {
     });
   };
 
-  buildRequest = indexOfCellRun => {
+  buildRequest = (indexOfCellRun, language) => {
     const codeStrArray = [];
     const allCells = this.state.cells;
-    const language = allCells[indexOfCellRun].type;
     const pendingCellIndexes = [];
     for (let i = 0; i <= indexOfCellRun; i += 1) {
       const cell = allCells[i];
       if (i <= indexOfCellRun && cell.type === language) {
-        codeStrArray.push(cell.code + "\n");
+        codeStrArray.push(cell.code);
         pendingCellIndexes.push(i);
       }
     }
@@ -138,8 +137,25 @@ class Notebook extends Component {
     return { language, codeStrArray };
   };
 
+  removeSameLanguageResults = language => {
+    const newCells = this.state.cells.map(cell => {
+      if (cell.type === language) {
+        return Object.assign({}, cell, {
+          results: { output: "", error: "", return: "" }
+        });
+      } else {
+        return cell;
+      }
+    });
+
+    this.setState({ cells: newCells });
+  };
+
   handleRunClick = indexOfCellRun => {
-    const requestObject = this.buildRequest(indexOfCellRun);
+    const allCells = this.state.cells;
+    const language = allCells[indexOfCellRun].type;
+    this.removeSameLanguageResults(language);
+    const requestObject = this.buildRequest(indexOfCellRun, language);
     this.ws.send(JSON.stringify(requestObject));
   };
 
@@ -165,6 +181,7 @@ class Notebook extends Component {
   };
 
   handleUpdateCodeState = (code, index) => {
+    console.log(code);
     this.setState(prevState => {
       const newCells = [...prevState.cells];
       const cellToUpdate = newCells[index];

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -7,35 +7,27 @@ class Notebook extends Component {
   state = {
     defaultLanguage: "Javascript",
     cells: [
+      // {
+      //   type: "Markdown",
+      //   code:
+      //     "# Welcome to RedPoint Notebook\n- A virtual sandbox for sharing runnable code ",
+      //   rendered: true
+      // },
       {
-        type: "Markdown",
-        code:
-          "# Welcome to RedPoint Notebook\n- A virtual sandbox for sharing runnable code ",
-        rendered: true
+        type: "Javascript",
+        code: "console.log('hi');\nconsole.log('there');",
+        results: { output: "", error: "", return: "" }
+      },
+      {
+        type: "Ruby",
+        code: "puts 'hi guys!'",
+        results: { output: "", error: "", return: "" }
       },
       {
         type: "Javascript",
-        code: "console.log('hi');\nconsole.log('there');\n",
+        code: "console.log('Hello, nice to meet you.');\nname",
         results: { output: "", error: "", return: "" }
       }
-      // {
-      //   type: "Javascript",
-      //   code: "console.log('hello from cell 2');",
-      //   results: { output: "hello from cell 2", return: "undefined" }
-      // },
-      // {
-      //   type: "Javascript",
-      //   code: "console.log('Hello, nice to meet you.');\nname",
-      //   results: {
-      //     output: "Hello, nice to meet you.",
-      //     error: "ReferenceError: name is not defined"
-      //   }
-      // },
-      // {
-      //   type: "Markdown",
-      //   code: "### Hi, here is some markdown text.",
-      //   rendered: false
-      // }
     ],
     // pendingCellExecution: true,
     pendingCellIndexes: [],
@@ -46,19 +38,7 @@ class Notebook extends Component {
 
   componentDidMount() {
     this.ws.onopen = event => {
-      // receiving the message from server
-      // let currentCell = 0;
-      // ws.onmessage = message => {
-      //   message = JSON.parse(message.data);
-      //   console.log(message.data);
-      //   console.log(message.type);
-      //   switch (message.type) {
-      //     case "stdout":
-      //       this.setState({ response: message.data });
-      //       break;
-      //     default:
-      //       console.log("No stdout received");
-      //   }
+      console.log("Websockets open!");
     };
 
     this.ws.onmessage = message => {
@@ -192,7 +172,6 @@ class Notebook extends Component {
   };
 
   handleUpdateCodeState = (code, index) => {
-    console.log(code);
     this.setState(prevState => {
       const newCells = [...prevState.cells];
       const cellToUpdate = newCells[index];

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -63,6 +63,11 @@ class Notebook extends Component {
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);
+
+      const cellIndex = this.state.pendingCellIndexes[
+        this.state.writeToPendingCellIndex
+      ];
+
       console.log(message.data);
       switch (message.type) {
         case "delimiter":
@@ -73,13 +78,10 @@ class Notebook extends Component {
           });
           break;
         case "stdout":
-          const cellIndex = this.state.pendingCellIndexes[
-            this.state.writeToPendingCellIndex
-          ];
           this.setState(prevState => {
             const newCells = [...prevState.cells].map((cell, index) => {
               if (index === cellIndex) {
-                cell.results.output += message.data + "\n";
+                cell.results.output += message.data;
                 return cell;
               } else {
                 return cell;
@@ -89,7 +91,19 @@ class Notebook extends Component {
             return { cells: newCells };
           });
           break;
-
+        case "return":
+          this.setState(prevState => {
+            const newCells = [...prevState.cells].map((cell, index) => {
+              if (index === cellIndex) {
+                cell.results.return += message.data;
+                return cell;
+              } else {
+                return cell;
+              }
+            });
+            return { cells: newCells };
+          });
+          break;
         default:
           console.log("Error, unknown message received from server");
       }

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -83,6 +83,10 @@ class Notebook extends Component {
         case "return":
           this.updateCellResults("return", cellIndex, message);
           break;
+        case "error":
+        case "stderr":
+          this.updateCellResults("error", cellIndex, message);
+          break;
         default:
           console.log("Error, unknown message received from server");
       }

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -78,31 +78,10 @@ class Notebook extends Component {
           });
           break;
         case "stdout":
-          this.setState(prevState => {
-            const newCells = [...prevState.cells].map((cell, index) => {
-              if (index === cellIndex) {
-                cell.results.output += message.data;
-                return cell;
-              } else {
-                return cell;
-              }
-            });
-
-            return { cells: newCells };
-          });
+          this.updateCellResults("output", cellIndex, message);
           break;
         case "return":
-          this.setState(prevState => {
-            const newCells = [...prevState.cells].map((cell, index) => {
-              if (index === cellIndex) {
-                cell.results.return += message.data;
-                return cell;
-              } else {
-                return cell;
-              }
-            });
-            return { cells: newCells };
-          });
+          this.updateCellResults("return", cellIndex, message);
           break;
         default:
           console.log("Error, unknown message received from server");
@@ -111,6 +90,20 @@ class Notebook extends Component {
       // this.receiveResponse(message);
     };
   }
+
+  updateCellResults = (resultType, cellIndex, message) => {
+    this.setState(prevState => {
+      const newCells = [...prevState.cells].map((cell, index) => {
+        if (index === cellIndex) {
+          cell.results[resultType] += message.data;
+          return cell;
+        } else {
+          return cell;
+        }
+      });
+      return { cells: newCells };
+    });
+  };
 
   handleSetDefaultLanguage = language => {
     this.setState({ defaultLanguage: language });

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ wss.on("connection", ws => {
 
   ws.on("message", msg => {
     const { language, codeStrArray } = JSON.parse(msg);
-    const codeString = codeStrArray.join("");
+    const codeString = codeStrArray.join("") + "\n";
     const delimiterStatement = generateDelimiter(language, delimiter);
     const scriptString = codeStrArray.join(delimiterStatement);
 


### PR DESCRIPTION
### What:
Resets results property on cells of same language as run cell.  Displays error, output and return under the cells of the same language as the run cell.  Adds newline to end of code string sent to server. 
![image](https://user-images.githubusercontent.com/25254258/68912618-a533ab80-0726-11ea-92fe-09c3de1afb12.png)

### Why:

### Next Steps:
Separate output on newlines.  Fix CSS so results aren't wider than code cell. 