### PR TITLE
Output renders on new lines

### DIFF
--- a/react-redpoint/src/Components/Cells/CellResults.jsx
+++ b/react-redpoint/src/Components/Cells/CellResults.jsx
@@ -12,7 +12,11 @@ class CellResults extends Component {
 
       switch (resultType) {
         case "output":
-          return <Output key={"output"} output={data} />;
+          // maps every time a message is received from stdout
+          const outputLines = data.map(outputline => {
+            return <Output key={"output"} output={outputline} />;
+          });
+          return outputLines;
         case "return":
           return <Return key={"return"} returnVal={data} />;
         case "error":

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -16,17 +16,17 @@ class Notebook extends Component {
       {
         type: "Javascript",
         code: "console.log('hi');\nconsole.log('there');",
-        results: { output: "", error: "", return: "" }
+        results: { output: [], error: "", return: "" }
       },
       {
         type: "Ruby",
         code: "puts 'hi guys!'",
-        results: { output: "", error: "", return: "" }
+        results: { output: [], error: "", return: "" }
       },
       {
         type: "Javascript",
         code: "console.log('Hello, nice to meet you.');\nname",
-        results: { output: "", error: "", return: "" }
+        results: { output: [], error: "", return: "" }
       }
     ],
     // pendingCellExecution: true,
@@ -43,7 +43,6 @@ class Notebook extends Component {
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);
-      // debugger;
       const cellIndex = this.state.pendingCellIndexes[
         this.state.writeToPendingCellIndex
       ];
@@ -70,8 +69,6 @@ class Notebook extends Component {
         default:
           console.log("Error, unknown message received from server");
       }
-      // const message = JSON.parse(message.data);
-      // this.receiveResponse(message);
     };
   }
 
@@ -79,11 +76,13 @@ class Notebook extends Component {
     this.setState(prevState => {
       const newCells = [...prevState.cells].map((cell, index) => {
         if (index === cellIndex) {
-          cell.results[resultType] += message.data;
-          return cell;
-        } else {
-          return cell;
+          if (resultType === "output") {
+            cell.results[resultType].push(message.data);
+          } else {
+            cell.results[resultType] += message.data;
+          }
         }
+        return cell;
       });
       return { cells: newCells };
     });
@@ -107,7 +106,7 @@ class Notebook extends Component {
       newCells.splice(index, 0, {
         type: type,
         code: "",
-        results: { output: "", error: "", return: "" }
+        results: { output: [], error: "", return: "" }
       });
       return { cells: newCells };
     });
@@ -132,7 +131,7 @@ class Notebook extends Component {
     const newCells = this.state.cells.map(cell => {
       if (cell.type === language) {
         return Object.assign({}, cell, {
-          results: { output: "", error: "", return: "" }
+          results: { output: [], error: "", return: "" }
         });
       } else {
         return cell;

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -43,7 +43,7 @@ class Notebook extends Component {
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);
-
+      // debugger;
       const cellIndex = this.state.pendingCellIndexes[
         this.state.writeToPendingCellIndex
       ];
@@ -124,7 +124,7 @@ class Notebook extends Component {
         pendingCellIndexes.push(i);
       }
     }
-    this.setState({ pendingCellIndexes });
+    this.setState({ pendingCellIndexes, writeToPendingCellIndex: 0 });
     return { language, codeStrArray };
   };
 


### PR DESCRIPTION
### What:
Code cell.results.output is now an array. As new stdout messages are received from the server, they're pushed into that cell's output array. The code cell's CellResults component maps over the array to produce an array of <Output /> components.

<img width="1160" alt="Screen Shot 2019-11-15 at 11 04 13 AM" src="https://user-images.githubusercontent.com/29799847/68961309-b10b8600-0797-11ea-8792-962a4e668d5d.png">

### Why:
Render incoming stdout on newlines.
### Next Steps:
Currently we map over cell.results.output _every_ time an "output" message is received. Could be more efficient hold <Output />, <Return />, and <Error /> components in <CellResults /> state. Then, we could append to an array of <Output /> components rather than mapping a new array with every "output" message.