### PR TITLE
Moves run button to right of cell

### DIFF
--- a/react-redpoint/src/App.css
+++ b/react-redpoint/src/App.css
@@ -35,6 +35,11 @@
   background: #2b2b29;
 }
 
+.run-button {
+  margin-left: auto;
+  margin-right: 5px;
+}
+
 .cell-toolbar-markdown {
   background: #474b56;
   margin-bottom: 20px;

--- a/react-redpoint/src/Components/Shared/RunCellButton.jsx
+++ b/react-redpoint/src/Components/Shared/RunCellButton.jsx
@@ -7,8 +7,13 @@ const RunCellButton = props => {
   };
 
   return (
-    <Button onClick={handleRunClick} variant="secondary" size="sm">
-      <span>&#9658; Run</span>
+    <Button
+      className="run-button"
+      onClick={handleRunClick}
+      variant="secondary"
+      size="sm"
+    >
+      <span>&#9658;</span>
     </Button>
   );
 };


### PR DESCRIPTION
### What:
Moves run button to right of cell, next to delete button.  Removes text from run button. 

### Why:
Cleans up UI

### Next Steps:
This is probably a temporary move.  We don't want accidental clicks on delete when trying to run the cell. Ideally this button is in the lower right corner of the cell

![image](https://user-images.githubusercontent.com/25254258/68970769-0bb3da80-07b6-11ea-8453-e5940f5700c0.png)
