### PR TITLE
Save notebook serverside

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "concurrently \"nodemon --inspect ./server.js --ignore codeCellScripts/\" \"cd react-redpoint && npm start\""
+    "start": "concurrently \"nodemon --inspect ./server.js\" \"cd react-redpoint && npm start\""
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "codeCellScripts/*",
+      "savedNotebooks/*"
+    ]
   },
   "dependencies": {
     "body-parser": "^1.19.0",
@@ -17,11 +23,6 @@
     "morgan": "^1.9.1",
     "node-pty": "^0.9.0",
     "nodemon": "^1.19.4",
-    "nodemonConfig": {
-      "ignore": [
-        "codeCellScripts/"
-      ]
-    },
     "strip-ansi": "^5.2.0",
     "uuid": "^3.3.3",
     "ws": "^7.2.0"

--- a/react-redpoint/src/App.css
+++ b/react-redpoint/src/App.css
@@ -41,13 +41,6 @@
   margin-bottom: 20px;
 }
 
-.btn-secondary {
-  /* font-size: 25px; */
-  /* margin: -10px; */
-  /* font-weight: 600; */
-}
-
-/* To set margin on bottom add new cell button */
 .add-cell-btn {
   margin: 25px auto 25px;
 }

--- a/react-redpoint/src/Components/Cells/CellResults.jsx
+++ b/react-redpoint/src/Components/Cells/CellResults.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import ListGroup from "react-bootstrap/ListGroup";
 import Output from "./Output";
 import Return from "./Return";
@@ -14,7 +14,7 @@ const CellResults = props => {
       case "output":
         // maps every time a message is received from stdout
         const outputLines = data.map(outputline => {
-          return <Output key={"output"} output={outputline} />;
+          return <Output key={uuidv4()} output={outputline} />;
         });
         return outputLines;
       case "return":

--- a/react-redpoint/src/Components/Cells/CellsList.jsx
+++ b/react-redpoint/src/Components/Cells/CellsList.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import AddCellButton from "../Shared/AddCellButton";
 import CodeCellContainer from "./CodeCellContainer";
 import uuidv4 from "uuid/v4";

--- a/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
+++ b/react-redpoint/src/Components/Cells/CodeCellContainer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import CodeCell from "./CodeCell";
 import RenderedMarkdown from "./RenderedMarkdown";
 

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -3,6 +3,7 @@ import CellsList from "./Cells/CellsList";
 import Container from "react-bootstrap/Container";
 import NavigationBar from "./Shared/NavigationBar";
 // import ConfirmAction from "./Shared/ConfirmAction";
+import uuidv4 from "uuid";
 
 class Notebook extends Component {
   state = {
@@ -20,7 +21,7 @@ class Notebook extends Component {
         results: { output: [], error: "", return: "" }
       },
       {
-        type: "Markdown",
+        type: "Ruby",
         code: "puts 'hi guys!'",
         results: { output: [], error: "", return: "" }
       }
@@ -67,8 +68,12 @@ class Notebook extends Component {
         case "stderr":
           this.updateCellResults("error", cellIndex, message);
           break;
+        case "loadNotebook":
+          console.log("Received notebook data from server!");
+          console.dir(message.data);
+          break;
         default:
-          console.log("Error, unknown message received from server");
+          console.log("Error: Unknown message received from server");
       }
     };
   }
@@ -160,6 +165,17 @@ class Notebook extends Component {
     this.ws.send(JSON.stringify(requestObject));
   };
 
+  handleSaveClick = e => {
+    e.preventDefault();
+    const messageType = "saveNotebook";
+    const state = this.state;
+    const notebookId = uuidv4();
+    const notebook = { id: notebookId, state };
+    const request = JSON.stringify({ messageType, notebook });
+    console.log(request);
+    this.ws.send(request);
+  };
+
   handleLanguageChange = (type, cellIndex) => {
     this.setState(prevState => {
       const newCells = [...prevState.cells];
@@ -197,6 +213,7 @@ class Notebook extends Component {
           state={this.state}
           deleteAllCells={this.handleDeleteAllCells}
           setDefaultLanguage={this.handleSetDefaultLanguage}
+          onSaveClick={this.handleSaveClick}
         />
         {/* {this.state.deleteWarningVisible ? (
           <ConfirmAction
@@ -223,13 +240,3 @@ class Notebook extends Component {
 }
 
 export default Notebook;
-
-// DEMO:
-// cells: [
-//   { type: "markdown", code: "##Title" },
-// { type: "javascript", code: "console.log('hello');" }
-// ]
-
-/* <ul>
-          <h4>Websocket Response: {this.state.response}</h4>
-        </ul> */

--- a/react-redpoint/src/Components/Notebook.jsx
+++ b/react-redpoint/src/Components/Notebook.jsx
@@ -172,7 +172,7 @@ class Notebook extends Component {
     const notebookId = uuidv4();
     const notebook = { id: notebookId, state };
     const request = JSON.stringify({ messageType, notebook });
-    console.log(request);
+    console.log("Notebook save request sent");
     this.ws.send(request);
   };
 

--- a/react-redpoint/src/Components/Shared/NavigationBar.jsx
+++ b/react-redpoint/src/Components/Shared/NavigationBar.jsx
@@ -26,6 +26,7 @@ class NavigationBar extends React.Component {
   };
 
   handleDeleteAllClick = e => {
+    e.preventDefault();
     this.props.deleteAllCells();
     this.toggleDeleteWarning();
   };
@@ -63,6 +64,9 @@ class NavigationBar extends React.Component {
             <Nav className="mr-auto">
               <Nav.Link href="#home">Share</Nav.Link>
               <Nav.Link href="#foo">Clone</Nav.Link>
+              <Nav.Link href="#save" onClick={this.props.onSaveClick}>
+                Save
+              </Nav.Link>
               <Nav.Link href="#link" onClick={this.toggleDeleteWarning}>
                 Delete
               </Nav.Link>
@@ -75,7 +79,7 @@ class NavigationBar extends React.Component {
         {this.state.deleteWarningVisible ? (
           <ConfirmAction
             warningMessage={"Are you sure you want to delete all cells?"}
-            onYesClick={this.handleDeleteAllClick}
+            onYesClick={this.onDeleteAllClick}
             onNoClick={this.toggleDeleteWarning}
           />
         ) : null}

--- a/server.js
+++ b/server.js
@@ -39,7 +39,14 @@ wss.on("connection", ws => {
     console.log(parsedMessage);
 
     if (parsedMessage.messageType === "saveNotebook") {
-      saveNotebook(parsedMessage.notebook);
+      saveNotebook(parsedMessage.notebook)
+        .then(notebookId => {
+          // save notebook to server, then respond to client with notebookId?
+          // ws.send(JSON.stringify(notebookId));
+        })
+        .catch(error => {
+          console.log(error);
+        });
       // } else if (parsedMessage.messageType === "executeCode") {
     } else {
       const { language, codeStrArray } = parsedMessage;
@@ -88,7 +95,7 @@ const saveNotebook = notebook => {
           reject(error);
         } else {
           console.log(`AFTER SAVING NOTEBOOK: ${notebook.id}`);
-          resolve();
+          resolve(notebook.id);
         }
       }
     );

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const uuidv4 = require("uuid/v4");
 const express = require("express");
 const http = require("http");
 const Websocket = require("ws");
+const fs = require("fs");
 
 const app = express();
 const server = http.createServer(app);
@@ -34,26 +35,34 @@ wss.on("connection", ws => {
   // sendDelimiterToClient(ws, delimiter);
 
   ws.on("message", msg => {
-    const { language, codeStrArray } = JSON.parse(msg);
-    const codeString = codeStrArray.join("") + "\n";
-    const delimiterStatement = generateDelimiter(language, delimiter);
-    const scriptString = codeStrArray.join(delimiterStatement);
+    const parsedMessage = JSON.parse(msg);
+    console.log(parsedMessage);
 
-    // is this the best place to set language for upcoming data?
-    // ws.send(JSON.stringify({ type: "language", data: language }));
+    if (parsedMessage.messageType === "saveNotebook") {
+      saveNotebook(parsedMessage.notebook);
+      // } else if (parsedMessage.messageType === "executeCode") {
+    } else {
+      const { language, codeStrArray } = parsedMessage;
+      const codeString = codeStrArray.join("") + "\n";
+      const delimiterStatement = generateDelimiter(language, delimiter);
+      const scriptString = codeStrArray.join(delimiterStatement);
 
-    userScript.writeFile(scriptString, language).then(() => {
-      userScript
-        .execute(ws, delimiter)
-        .then(() => repl.execute(codeString, language))
-        .then(returnData => repl.parseOutput(returnData, language))
-        .then(returnValue => {
-          ws.send(JSON.stringify({ type: "return", data: returnValue }));
-        })
-        .catch(data => {
-          ws.send(data);
-        });
-    });
+      // is this the best place to set language for upcoming data?
+      // ws.send(JSON.stringify({ type: "language", data: language }));
+
+      userScript.writeFile(scriptString, language).then(() => {
+        userScript
+          .execute(ws, delimiter)
+          .then(() => repl.execute(codeString, language))
+          .then(returnData => repl.parseOutput(returnData, language))
+          .then(returnValue => {
+            ws.send(JSON.stringify({ type: "return", data: returnValue }));
+          })
+          .catch(data => {
+            ws.send(data);
+          });
+      });
+    }
   });
 });
 
@@ -64,3 +73,24 @@ app.get("/reacttest", (req, res) => {
 server.listen(8000, () => {
   console.log("App started");
 });
+
+const saveNotebook = notebook => {
+  return new Promise((resolve, reject) => {
+    console.log("BEFORE SAVING NOTEBOOK");
+    jsonNotebook = JSON.stringify(notebook);
+
+    fs.writeFile(
+      `./savedNotebooks/${notebook.id}.json`,
+      jsonNotebook,
+      error => {
+        if (error) {
+          console.log("ERROR SAVING NOTEBOOK");
+          reject(error);
+        } else {
+          console.log(`AFTER SAVING NOTEBOOK: ${notebook.id}`);
+          resolve();
+        }
+      }
+    );
+  });
+};


### PR DESCRIPTION
### What:
- On navbar `Save` click, state of notebook is sent to express server via websocket, where it gets saved as a JSON object with a uuidv4 filename in the format:
```js
{
  "id": "7dd893db-d32b-4abb-a700-4402df87d553",
  "state": {
    "defaultLanguage": "Javascript",
    "cells": [
      {
        "type": "Javascript",
        "code": "console.log('hi');\nconsole.log('there');",
        "results": { "output": [], "error": "", "return": "" }
      },
      {
        "type": "Ruby",
        "code": "puts 'hi guys!'",
        "results": { "output": [], "error": "", "return": "" }
      }
    ],
    "pendingCellIndexes": [],
    "writeToPendingCellIndex": 0
  }
}
```
- Addressed react unused component warnings

### Why:
- As first step in being able to save notebooks and then re-hydrate them

### Next Steps:
- Scrub results before saving
- Successfully load notebook from server
- Save notebooks to a database