### PR TITLE
Fix python return bug

### DIFF
--- a/client/src/Components/Cells/Error.jsx
+++ b/client/src/Components/Cells/Error.jsx
@@ -2,9 +2,19 @@ import React from "react";
 import ListGroup from "react-bootstrap/ListGroup";
 
 const Error = props => {
+  // const brError = props.error.replace(/\n/g, "\r\n");
+
+  const addLineBreaks = string =>
+    string.split("\n").map((text, index) => (
+      <React.Fragment key={`${text}-${index}`}>
+        {text}
+        <br />
+      </React.Fragment>
+    ));
+
   return props.error ? (
     <ListGroup.Item className="output" variant="danger">
-      {props.error}
+      {addLineBreaks(props.error)}
     </ListGroup.Item>
   ) : null;
 };

--- a/client/src/Components/Cells/Error.jsx
+++ b/client/src/Components/Cells/Error.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import ListGroup from "react-bootstrap/ListGroup";
 
 const Error = props => {
-  // const brError = props.error.replace(/\n/g, "\r\n");
-
   const addLineBreaks = string =>
     string.split("\n").map((text, index) => (
       <React.Fragment key={`${text}-${index}`}>
@@ -12,9 +10,11 @@ const Error = props => {
       </React.Fragment>
     ));
 
+  const cleanedError = props.error.replace(/.*user_script(.{4})/, "");
+
   return props.error ? (
     <ListGroup.Item className="output" variant="danger">
-      {addLineBreaks(props.error)}
+      {addLineBreaks(cleanedError)}
     </ListGroup.Item>
   ) : null;
 };

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -22,7 +22,7 @@ class Notebook extends Component {
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);
-      debugger;
+
       const cellIndex = this.state.pendingCellIndexes[
         this.state.writeToPendingCellIndex
       ];

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -27,7 +27,8 @@ class Notebook extends Component {
         this.state.writeToPendingCellIndex
       ];
 
-      console.log(message.data);
+      console.log(JSON.stringify(message.data));
+
       switch (message.type) {
         case "delimiter":
           this.setState(prevState => {
@@ -43,6 +44,7 @@ class Notebook extends Component {
           this.updateCellResults("return", cellIndex, message);
           break;
         case "error":
+          break;
         case "stderr":
           this.updateCellResults("error", cellIndex, message);
           break;

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -22,6 +22,7 @@ class Notebook extends Component {
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);
+      debugger;
       const cellIndex = this.state.pendingCellIndexes[
         this.state.writeToPendingCellIndex
       ];

--- a/libs/modules/repl.js
+++ b/libs/modules/repl.js
@@ -24,7 +24,9 @@ const repl = {
     }
 
     return new Promise(resolve => {
-      console.log(`Repl Command: ${codeString + replExitMessage}`);
+      console.log(
+        JSON.stringify(`Repl Command: ${codeString + replExitMessage}`)
+      );
       const node = pty.spawn(replType);
       let returnData = "";
       node.onData(data => (returnData += stripAnsi(data)));

--- a/savedNotebooks/95fda913-5704-4044-b624-fb25f590c136.json
+++ b/savedNotebooks/95fda913-5704-4044-b624-fb25f590c136.json
@@ -1,0 +1,1 @@
+{"cells":[{"type":"Javascript","code":"console.log('hi there');","results":{"output":[],"error":"","return":""}},{"type":"Javascript","code":"let foo = 'bar'","results":{"output":[],"error":"","return":""}}],"pendingCellIndexes":[0,1],"writeToPendingCellIndex":1,"id":"95fda913-5704-4044-b624-fb25f590c136"}

--- a/savedNotebooks/9d84ea2d-62bf-4642-b6e6-80ab6f239efc.json
+++ b/savedNotebooks/9d84ea2d-62bf-4642-b6e6-80ab6f239efc.json
@@ -1,0 +1,1 @@
+{"cells":[{"type":"Markdown","code":"I don't know about this...","results":{"output":[],"error":"","return":""},"rendered":true}],"pendingCellIndexes":[],"writeToPendingCellIndex":0,"id":"9d84ea2d-62bf-4642-b6e6-80ab6f239efc"}

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ const generateDelimiter = (language, delimiter) => {
     case "Javascript":
       return `console.log('${delimiter}');\n`;
     case "Python":
-      return `print(${delimiter})\n`;
+      return `print('${delimiter}')\n`;
   }
 };
 
@@ -64,7 +64,7 @@ wss.on("connection", ws => {
         });
     } else {
       const { language, codeStrArray } = message;
-      const codeString = codeStrArray.join("") + "\n";
+      const codeString = codeStrArray.join("");
       const delimiterStatement = generateDelimiter(language, delimiter);
       const scriptString = codeStrArray.join(delimiterStatement);
 


### PR DESCRIPTION
### What:
Cleans up error message displays: 
- adds quotes to UUID delimiter print statement for Python
- adds helper to set line breaks for error messages
- adds regex to scrub user_script info from error messages
- sets `break` for `error` case in Notebook to keep this message type out of CellResults Error display
### Why:
Make error messages easier to read
### Next Steps:
- Line numbers are preserved in error message, in the hopes of finding a way to make CodeMirror line numbers contiguous across like languages

- We need to add logic for MAXBUFFER and SIGINT error types to the React frontend

- Bug:   for some reason, Ruby and Python stderr that comes out of `exec` is truncated compared to running the same user_script on the command line


![image](https://user-images.githubusercontent.com/25254258/69002317-dc3ac600-08ba-11ea-9ea0-6c0066f9122a.png)
