### PR TITLE
Changing language clears all results from changed cell

### DIFF
--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -184,6 +184,9 @@ class Notebook extends Component {
       if (type === "Markdown") {
         changedCell.rendered = false;
       }
+      if (changedCell.results) {
+        changedCell.results = { output: [], error: "", return: "" };
+      }
       return { cells: newCells };
     });
   };


### PR DESCRIPTION
### What:
Changing language of a cell clears results from that cell (unless you click the current language in the dropdown)
### Why:
Results are not valid for the new language type
### Next Steps:
Work on focusing cells on add new cell

![2019-11-17 20 12 25](https://user-images.githubusercontent.com/25254258/69017845-60528380-0977-11ea-872b-da2b995e78c5.gif)