### PR TITLE
Fix UUID bug

### DIFF
--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -8,7 +8,7 @@ const CellsList = props => {
     return (
       <CodeCellContainer
         cell={cell}
-        key={uuidv4()}
+        key={cell.id}
         onDeleteCellClick={props.onDeleteCellClick}
         onAddCellClick={props.onAddCellClick}
         cellIndex={index}

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import AddCellButton from "../Shared/AddCellButton";
 import CodeCellContainer from "./CodeCellContainer";
-import uuidv4 from "uuid/v4";
 
 const CellsList = props => {
   const cellContainers = props.cells.map((cell, index) => {

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -21,8 +21,9 @@ const CellsList = props => {
   });
 
   cellContainers.push(
-    <div className="add-cell-container">
+    <div className="add-cell-container" key="add-cell-container">
       <AddCellButton
+        key="add-cell-btn"
         className="add-cell-btn"
         cellIndex={cellContainers.length}
         onClick={props.onAddCellClick}

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -21,12 +21,11 @@ const CellsList = props => {
   });
 
   cellContainers.push(
-    <div className="add-cell-container" key={uuidv4()}>
+    <div className="add-cell-container">
       <AddCellButton
         className="add-cell-btn"
         cellIndex={cellContainers.length}
         onClick={props.onAddCellClick}
-        key={uuidv4()}
       />
     </div>
   );

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -22,22 +22,9 @@ class CodeCell extends Component {
   handleBlur = (event, editor) => {
     this.props.onUpdateCodeState(this.state.code, this.props.cellIndex);
 
-    // within onBlur, relatedTarget is the EventTarget receiving focus (if any)
-    // const nextTarget = event.relatedTarget;
-    // if (nextTarget) {
-    //   if (nextTarget.className.includes("run-button")) {
-    //     this.props.onRunClick(+nextTarget.getAttribute("cellindex"));
-    //   }
-    // }
-
     if (this.props.language === "Markdown") {
       this.props.toggleRender(this.props.cellIndex);
     }
-  };
-
-  handleDidMount = editor => {
-    debugger;
-    editor.focus();
   };
 
   render() {
@@ -59,11 +46,6 @@ class CodeCell extends Component {
           this.props.onRunClick(this.props.cellIndex);
         }
       }
-
-      // autofocus creates an infinite loop onBlur
-      // autofocus: true
-      // uncomment to disable cm focus for read-only notebooks
-      // readOnly: "nocursor",
     };
 
     return (
@@ -91,10 +73,6 @@ class CodeCell extends Component {
           }}
           onBlur={(editor, event) => {
             this.handleBlur(event, editor);
-          }}
-          editorDidMount={editor => {
-            this.handleDidMount(editor);
-            console.log(editor);
           }}
         />
         {cell.language !== "Markdown" ? (

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -23,12 +23,12 @@ class CodeCell extends Component {
     this.props.onUpdateCodeState(this.state.code, this.props.cellIndex);
 
     // within onBlur, relatedTarget is the EventTarget receiving focus (if any)
-    const nextTarget = event.relatedTarget;
-    if (nextTarget) {
-      if (nextTarget.className.includes("run-button")) {
-        this.props.onRunClick(+nextTarget.getAttribute("cellindex"));
-      }
-    }
+    // const nextTarget = event.relatedTarget;
+    // if (nextTarget) {
+    //   if (nextTarget.className.includes("run-button")) {
+    //     this.props.onRunClick(+nextTarget.getAttribute("cellindex"));
+    //   }
+    // }
 
     if (this.props.language === "Markdown") {
       this.props.toggleRender(this.props.cellIndex);

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -36,7 +36,7 @@ class CodeCell extends Component {
   };
 
   handleDidMount = editor => {
-    // this focuses on mount, but prevents blurring from component
+    debugger;
     editor.focus();
   };
 
@@ -92,10 +92,10 @@ class CodeCell extends Component {
           onBlur={(editor, event) => {
             this.handleBlur(event, editor);
           }}
-          // editorDidMount={editor => {
-          //   this.handleDidMount(editor);
-          //   console.log(editor);
-          // }}
+          editorDidMount={editor => {
+            this.handleDidMount(editor);
+            console.log(editor);
+          }}
         />
         {cell.language !== "Markdown" ? (
           <CellResults language={cell.language} results={cell.results} />

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -245,9 +245,13 @@ class Notebook extends Component {
 
   handleUpdateCodeState = (code, index) => {
     this.setState(prevState => {
-      const newCells = [...prevState.cells];
-      const cellToUpdate = newCells[index];
-      cellToUpdate.code = code;
+      const newCells = [...prevState.cells].map((cell, idx) => {
+        if (idx === index) {
+          return Object.assign({}, cell, { code: code });
+        } else {
+          return cell;
+        }
+      });
       return { cells: newCells };
     });
   };

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -125,7 +125,8 @@ class Notebook extends Component {
       newCells.splice(index, 0, {
         language: language,
         code: "",
-        results: { stdout: [], error: "", return: "" }
+        results: { stdout: [], error: "", return: "" },
+        id: uuidv4()
       });
       return { cells: newCells };
     });

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -43,7 +43,6 @@ const userScript = {
                 .slice(0, scriptErrorIdx)
                 .filter(line => {
                   const delimRegex = new RegExp(delimiter);
-                  debugger;
                   return delimRegex.test(line);
                 }).length;
 
@@ -74,7 +73,6 @@ const userScript = {
               );
               reject();
             }
-
           }
         }
       );


### PR DESCRIPTION
### What:

- Removes UUIDs as keys for rendering individual components.  Sets UUID as an `id` property on a cell in `Notebook` state when a cell is created.  
- Refactors `handleUpdateCodeState` to not mutate state.  
- Removes `nextTarget` logic from `CodeCell` to prevent double running of cell on run click
### Why:
Fixes double-click bug for buttons.  Fixes bug where cells are run twice on run button click
### Next Steps:
- Looks like `updateCodeState` is also mutating state directly, this needs refactoring 