### PR TITLE
send save requests to subdomain so we can associate a session with a …

### DIFF
--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -238,7 +238,7 @@ class Notebook extends Component {
     const serializedNotebook = JSON.stringify(notebook);
     console.log("Notebook save request sent");
 
-    fetch(`${PROXY_URL}/update`, {
+    fetch(`/update`, {
       method: "post",
       mode: "cors",
       cache: "no-cache",


### PR DESCRIPTION
…notebook id

### What:
Posts notebook save requests to the subdomained address so the proxy server can update the session to include a notebook id. Upon page refresh, `loadState` is now able to hydrate the page from the saved data.

### Why:
Previously, a page refresh would erase the notebook data for a session - even if the notebook had been saved.

