### PR TITLE
Add code execution spinner

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -97,7 +97,7 @@ div .rendered-markdown {
 }
 
 .navbar-spinner {
-  margin: 12px 10px !important;
+  margin: 12px 40px !important;
 }
 
 .cellbar-spinner {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -95,3 +95,7 @@ div .rendered-markdown {
 .dropdown-toggle:after {
   content: none !important;
 }
+
+.navbar-spinner {
+  margin: 12px 10px !important;
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -99,3 +99,9 @@ div .rendered-markdown {
 .navbar-spinner {
   margin: 12px 10px !important;
 }
+
+.cellbar-spinner {
+  margin-top: 8px;
+  margin-left: auto;
+  margin-right: 12px;
+}

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -15,7 +15,7 @@ const CellsList = props => {
         toggleRender={props.toggleRender}
         onUpdateCodeState={props.onUpdateCodeState}
         onRunClick={props.onRunClick}
-        awaitingServerResponse={props.awaitingServerResponse}
+        languagePending={props.languagePending}
       />
     );
   });

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -15,6 +15,7 @@ const CellsList = props => {
         toggleRender={props.toggleRender}
         onUpdateCodeState={props.onUpdateCodeState}
         onRunClick={props.onRunClick}
+        awaitingServerResponse={props.awaitingServerResponse}
       />
     );
   });

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -70,6 +70,7 @@ class CodeCell extends Component {
           rendered={cell.rendered}
           onRunClick={this.props.onRunClick}
           cellCodeState={this.state.code}
+          awaitingServerResponse={this.props.awaitingServerResponse}
         />
         <CodeMirror
           value={this.state.code}

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -70,7 +70,7 @@ class CodeCell extends Component {
           rendered={cell.rendered}
           onRunClick={this.props.onRunClick}
           cellCodeState={this.state.code}
-          awaitingServerResponse={this.props.awaitingServerResponse}
+          languagePending={this.props.languagePending}
         />
         <CodeMirror
           value={this.state.code}

--- a/client/src/Components/Cells/CodeCellContainer.jsx
+++ b/client/src/Components/Cells/CodeCellContainer.jsx
@@ -27,6 +27,7 @@ const CodeCellContainer = props => {
       toggleRender={props.toggleRender}
       onUpdateCodeState={props.onUpdateCodeState}
       onRunClick={props.onRunClick}
+      awaitingServerResponse={props.awaitingServerResponse}
     />
   );
 };

--- a/client/src/Components/Cells/CodeCellContainer.jsx
+++ b/client/src/Components/Cells/CodeCellContainer.jsx
@@ -27,7 +27,7 @@ const CodeCellContainer = props => {
       toggleRender={props.toggleRender}
       onUpdateCodeState={props.onUpdateCodeState}
       onRunClick={props.onRunClick}
-      awaitingServerResponse={props.awaitingServerResponse}
+      languagePending={props.languagePending}
     />
   );
 };

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -68,6 +68,7 @@ class Notebook extends Component {
       let cellIndex = findCellIndex(message, this.state);
 
       console.log(JSON.stringify(message.data));
+      let stopLanguagePending;
 
       switch (message.type) {
         case "delimiter":
@@ -85,7 +86,7 @@ class Notebook extends Component {
           break;
         case "return":
         case "error":
-          const stopLanguagePending = makeStopPendingObj(message.language);
+          stopLanguagePending = makeStopPendingObj(message.language);
           this.setState(stopLanguagePending);
           this.updateCellResults(message.type, cellIndex, message);
           break;
@@ -93,6 +94,8 @@ class Notebook extends Component {
         //   this.updateCellResults("error", cellIndex, message);
         //   break;
         case "syntax-error":
+          stopLanguagePending = makeStopPendingObj(message.language);
+          this.setState(stopLanguagePending);
           cellIndex = findSyntaxErrorIdx(
             message,
             this.state.RubyPendingIndexes,

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -312,11 +312,20 @@ class Notebook extends Component {
     });
   };
 
+  awaitingServerResponse = () => {
+    return (
+      this.state.RubyCodePending ||
+      this.state.JavascriptCodePending ||
+      this.state.PythonCodePending
+    );
+  };
+
   render() {
     return (
       <div>
         <NavigationBar
           state={this.state}
+          awaitingServerResponse={this.awaitingServerResponse}
           deleteAllCells={this.handleDeleteAllCells}
           onSaveClick={this.handleSaveClick}
           onLoadClick={this.handleLoadClick}
@@ -325,6 +334,7 @@ class Notebook extends Component {
         />
         <Container className="App-body">
           <CellsList
+            awaitingServerResponse={this.awaitingServerResponse}
             onDeleteCellClick={this.handleDeleteCellClick}
             onAddCellClick={this.handleAddCellClick}
             cells={this.state.cells}

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -320,6 +320,20 @@ class Notebook extends Component {
     );
   };
 
+  languagePending = language => {
+    switch (language) {
+      case "Ruby":
+        return this.state.RubyCodePending;
+      case "Javascript":
+        return this.state.JavascriptCodePending;
+      case "Python":
+        return this.state.PythonCodePending;
+      default:
+        console.log("Error: Invalid Language Supplied in languagePending()");
+        return null;
+    }
+  };
+
   render() {
     return (
       <div>
@@ -334,7 +348,7 @@ class Notebook extends Component {
         />
         <Container className="App-body">
           <CellsList
-            awaitingServerResponse={this.awaitingServerResponse}
+            languagePending={this.languagePending}
             onDeleteCellClick={this.handleDeleteCellClick}
             onAddCellClick={this.handleAddCellClick}
             cells={this.state.cells}

--- a/client/src/Components/Shared/CellToolbar.jsx
+++ b/client/src/Components/Shared/CellToolbar.jsx
@@ -19,10 +19,11 @@ const CellToolbar = props => {
       ></ChangeLanguageDropdown>
       {props.language !== "Markdown" ? (
         <RunButtonOrSpinner
+          language={props.language}
           onClick={props.onRunClick}
           cellIndex={props.cellIndex}
           cellCodeState={props.cellCodeState}
-          awaitingServerResponse={props.awaitingServerResponse}
+          languagePending={props.languagePending}
         ></RunButtonOrSpinner>
       ) : null}
       <DeleteCellButton

--- a/client/src/Components/Shared/CellToolbar.jsx
+++ b/client/src/Components/Shared/CellToolbar.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import DeleteCellButton from "./DeleteCellButton";
 import ChangeLanguageDropdown from "./ChangeLanguageDropdown";
-import RunCellButton from "./RunCellButton";
+import RunButtonOrSpinner from "./RunButtonOrSpinner";
 
 const CellToolbar = props => {
   return (
@@ -18,11 +18,12 @@ const CellToolbar = props => {
         cellIndex={props.cellIndex}
       ></ChangeLanguageDropdown>
       {props.language !== "Markdown" ? (
-        <RunCellButton
+        <RunButtonOrSpinner
           onClick={props.onRunClick}
           cellIndex={props.cellIndex}
           cellCodeState={props.cellCodeState}
-        ></RunCellButton>
+          awaitingServerResponse={props.awaitingServerResponse}
+        ></RunButtonOrSpinner>
       ) : null}
       <DeleteCellButton
         onClick={props.onDeleteClick}

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -4,6 +4,7 @@ import logo from "../../placeholder_logo.svg";
 import Navbar from "react-bootstrap/Navbar";
 import ConfirmAction from "./ConfirmAction";
 import LoadForm from "./LoadForm";
+import Spinner from "react-bootstrap/Spinner";
 
 class NavigationBar extends React.Component {
   state = {
@@ -41,6 +42,14 @@ class NavigationBar extends React.Component {
         loadFormVisible: !prevState.loadFormVisible
       };
     });
+  };
+
+  awaitingCode = () => {
+    return (
+      this.props.state.RubyCodePending ||
+      this.props.state.JavascriptCodePending ||
+      this.props.state.PythonCodePending
+    );
   };
 
   render() {
@@ -83,9 +92,18 @@ class NavigationBar extends React.Component {
                 Clear Results
               </Nav.Link>
               <Navbar.Text>|</Navbar.Text>
-              <Nav.Link href="#runAll" onClick={this.props.onRunAllClick}>
-                Run All Cells
-              </Nav.Link>
+              {this.awaitingCode() ? (
+                <Spinner
+                  className="navbar-spinner"
+                  animation="border"
+                  variant="secondary"
+                  size="sm"
+                />
+              ) : (
+                <Nav.Link href="#runAll" onClick={this.props.onRunAllClick}>
+                  Run All Cells
+                </Nav.Link>
+              )}
             </Nav>
           </Navbar.Collapse>
         </Navbar>

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -44,14 +44,6 @@ class NavigationBar extends React.Component {
     });
   };
 
-  awaitingCode = () => {
-    return (
-      this.props.state.RubyCodePending ||
-      this.props.state.JavascriptCodePending ||
-      this.props.state.PythonCodePending
-    );
-  };
-
   render() {
     return (
       <React.Fragment>
@@ -92,7 +84,7 @@ class NavigationBar extends React.Component {
                 Clear Results
               </Nav.Link>
               <Navbar.Text>|</Navbar.Text>
-              {this.awaitingCode() ? (
+              {this.props.awaitingServerResponse() ? (
                 <Spinner
                   className="navbar-spinner"
                   animation="border"

--- a/client/src/Components/Shared/RunButtonOrSpinner.jsx
+++ b/client/src/Components/Shared/RunButtonOrSpinner.jsx
@@ -3,7 +3,7 @@ import RunCellButton from "./RunCellButton";
 import Spinner from "react-bootstrap/Spinner";
 
 const RunButtonOrSpinner = props => {
-  return props.awaitingServerResponse() ? (
+  return props.languagePending(props.language) ? (
     <Spinner
       as="span"
       className="cellbar-spinner"

--- a/client/src/Components/Shared/RunButtonOrSpinner.jsx
+++ b/client/src/Components/Shared/RunButtonOrSpinner.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import RunCellButton from "./RunCellButton";
 import Spinner from "react-bootstrap/Spinner";
 

--- a/client/src/Components/Shared/RunButtonOrSpinner.jsx
+++ b/client/src/Components/Shared/RunButtonOrSpinner.jsx
@@ -1,0 +1,23 @@
+import React, { Component } from "react";
+import RunCellButton from "./RunCellButton";
+import Spinner from "react-bootstrap/Spinner";
+
+const RunButtonOrSpinner = props => {
+  return props.awaitingServerResponse() ? (
+    <Spinner
+      as="span"
+      className="cellbar-spinner"
+      animation="border"
+      variant="secondary"
+      size="sm"
+    />
+  ) : (
+    <RunCellButton
+      onClick={props.onClick}
+      cellIndex={props.cellIndex}
+      cellCodeState={props.cellCodeState}
+    ></RunCellButton>
+  );
+};
+
+export default RunButtonOrSpinner;

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -73,3 +73,17 @@ export const findPendingIndex = language => {
       return null;
   }
 };
+
+export const makeStopPendingObj = language => {
+  switch (language) {
+    case "Ruby":
+      return { RubyCodePending: false };
+    case "Javascript":
+      return { JavascriptCodePending: false };
+    case "Python":
+      return { PythonCodePending: false };
+    default:
+      console.log("Error: Invalid Language Supplied in Server Message");
+      return null;
+  }
+};

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,1 +1,1 @@
-console.log('hi');
+console.log('hey');

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,1 +1,1 @@
-console.log('hey');
+console.log('hi');

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,1 +1,1 @@
-console.log('hey you');
+console.log('hey');

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,3 +1,5 @@
 for (let i = 0; i <= 10; i += 1) {
 	console.log(i)
 }
+console.log('ccae72e9-522e-451d-a8ee-3fcfeac4a10a');
+

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,1 +1,3 @@
-console.log('hey');
+for (let i = 0; i <= 10; i += 1) {
+	console.log(i)
+}

--- a/codeCellScripts/user_script.py
+++ b/codeCellScripts/user_script.py
@@ -1,1 +1,1 @@
-print('hello')
+print('hey')

--- a/codeCellScripts/user_script.py
+++ b/codeCellScripts/user_script.py
@@ -1,1 +1,3 @@
 print("boo\n" * 10)
+print('ccae72e9-522e-451d-a8ee-3fcfeac4a10a')
+

--- a/codeCellScripts/user_script.py
+++ b/codeCellScripts/user_script.py
@@ -1,1 +1,1 @@
-print('hey')
+print("boo\n" * 10)

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,3 @@
-1.upto(10) { |n| puts n }
+
+puts "69fe209a-8711-4503-99b0-ff6ddcdb1ab0"
+puts 'hi'

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-puts 'hi'
+1.upto(10) { |n| puts n }

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-puts 'hi'
+1.upto(49) {|n| puts n }

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-1.upto(49) {|n| puts n }
+puts 'hi'


### PR DESCRIPTION
### What:
- Added spinner animations while awaiting code execution response for Navbar and cellToolbars
- For cell toolbars, spinners only activate if awaiting code execution of cell language
- For NavBar, spinner activates if awaiting code execution of any language
 
### Why:
- More responsive UX

### Next Steps:
- Fix issue when code cells only contain newline characters (creates buggy output)