### PR TITLE
Container teardown

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+node_modules/*
 .git
 .github
 yarn-error.log

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7943,6 +7943,14 @@
           "version": "5.7.3",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -13920,11 +13928,11 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "x-is-string": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^16.11.0",
     "react-markdown": "^4.2.2",
     "react-scripts": "3.2.0",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "ws": "^7.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -3,6 +3,7 @@ import CellsList from "./Cells/CellsList";
 import Container from "react-bootstrap/Container";
 import NavigationBar from "./Shared/NavigationBar";
 import uuidv4 from "uuid";
+
 import {
   findSyntaxErrorIdx,
   findPendingIndex,
@@ -49,16 +50,24 @@ class Notebook extends Component {
       });
   };
 
-  componentDidMount() {
-    this.loadState();
-
+  establishWebsocket = () => {
     if (process.env.NODE_ENV === "development") {
       this.ws = new WebSocket("ws://localhost:8000");
     } else if (process.env.NODE_ENV === "production") {
       this.ws = new WebSocket("ws://" + window.location.host);
     }
+  };
+
+  componentDidMount() {
+    // this.loadState();
+    this.establishWebsocket();
 
     this.ws.onopen = e => console.log(window.location.host);
+
+    // this.ws.onclose = () => {
+    //   this.establishWebsocket();
+    //   // console.log(this.ws.readyState);
+    // };
 
     this.ws.onmessage = message => {
       message = JSON.parse(message.data);

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -59,23 +59,6 @@ class Notebook extends Component {
     }
   };
 
-  // componentWillUnmount() {
-  // this.ws.close();
-  // fetch(`http://www.redpointnotebook.com`, {
-  // method: "delete"
-  // mode: "cors",
-  // cache: "no-cache"
-  // body: serializedNotebook,
-  // headers: { "Content-Type": "text/plain" }
-  // });
-  // .then(res => {
-  //   return res.text();
-  // })
-  // .then(data => {
-  //   return data;
-  // });
-  // }
-
   componentDidMount() {
     this.loadState();
     this.establishWebsocket();
@@ -90,6 +73,8 @@ class Notebook extends Component {
       console.log("Error encountered : ", e);
     };
     // this.ws.onclose = () => {
+    //   reestablish when websocket times out?
+
     //   this.establishWebsocket();
     //   // console.log(this.ws.readyState);
     // };

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -13,7 +13,6 @@ import {
 } from "../utils";
 import { SIGTERM_ERROR_MESSAGE, PROXY_URL } from "../Constants/constants";
 import { LANGUAGES } from "../Constants/constants";
-// import { start } from "repl";
 
 class Notebook extends Component {
   state = {

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -13,6 +13,7 @@ import {
 } from "../utils";
 import { SIGTERM_ERROR_MESSAGE, PROXY_URL } from "../Constants/constants";
 import { LANGUAGES } from "../Constants/constants";
+// import { start } from "repl";
 
 class Notebook extends Component {
   state = {
@@ -58,12 +59,36 @@ class Notebook extends Component {
     }
   };
 
+  // componentWillUnmount() {
+  // this.ws.close();
+  // fetch(`http://www.redpointnotebook.com`, {
+  // method: "delete"
+  // mode: "cors",
+  // cache: "no-cache"
+  // body: serializedNotebook,
+  // headers: { "Content-Type": "text/plain" }
+  // });
+  // .then(res => {
+  //   return res.text();
+  // })
+  // .then(data => {
+  //   return data;
+  // });
+  // }
+
   componentDidMount() {
-    // this.loadState();
+    this.loadState();
     this.establishWebsocket();
-
-    this.ws.onopen = e => console.log(window.location.host);
-
+    this.ws.onopen = e => {
+      let urlNoProtocol = e.target.url.replace(/ws:\/\//, "");
+      console.log("urlNoProtocol", urlNoProtocol);
+      this.ws.send(
+        JSON.stringify({ type: "sessionAddress", data: urlNoProtocol })
+      );
+    };
+    this.ws.onerror = e => {
+      console.log("Error encountered : ", e);
+    };
     // this.ws.onclose = () => {
     //   this.establishWebsocket();
     //   // console.log(this.ws.readyState);

--- a/codeCellScripts/user_script.py
+++ b/codeCellScripts/user_script.py
@@ -1,2 +1,2 @@
-while True:
-	print('hi')
+for i in range(10):
+	print(i)

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-p 'hi'
+p 'yoyoyo'

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-p 'yoyoyo'
+p 'hi'

--- a/libs/modules/repl.js
+++ b/libs/modules/repl.js
@@ -18,7 +18,7 @@ const repl = {
         replType = "node";
         break;
       case "Python":
-        replExitMessage = "exit()\r";
+        replExitMessage = "\nexit()\r";
         replType = "python";
         break;
     }

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -79,7 +79,6 @@ const userScript = {
 
       scriptProcess.stdout.on("data", data => {
         buffer.push(data);
-
         setTimeout(() => {
           const bufferArray = buffer.join("").split("\n");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1995,6 +1995,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-pty": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "markdown-it": "^10.0.0",
     "mongodb": "^3.3.4",
     "morgan": "^1.9.1",
+    "node-fetch": "^2.6.0",
     "node-pty": "^0.9.0",
     "nodemon": "^1.19.4",
     "strip-ansi": "^5.2.0",

--- a/server.js
+++ b/server.js
@@ -29,17 +29,6 @@ const generateDelimiter = (language, delimiter) => {
   }
 };
 
-// on connection, isAlive is set to true
-//
-// server calls ws.ping(someFunc);
-// by convention, client responds with a pong()
-// when server receives pong, heartbeat is called which resets
-// isAlive to true
-// every n seconds, the server pings the client
-// after pinging the client, isAlive is set to false
-// if a pong is not received after the timeout period, the server terminates
-// the websocket connection
-
 function heartbeat(ws) {
   ws.isAlive = true;
 }

--- a/server.js
+++ b/server.js
@@ -28,9 +28,24 @@ const generateDelimiter = (language, delimiter) => {
   }
 };
 
+// on connection, isAlive is set to true
+//
+// server calls ws.ping(someFunc);
+// by convention, client responds with a pong()
+// when server receives pong, heartbeat is called which resets
+// isAlive to true
+// every n seconds, the server pings the client
+// after pinging the client, isAlive is set to false
+// if a pong is not received after the timeout period, the server terminates
+// the websocket connection
+
 wss.on("connection", ws => {
   const delimiter = uuidv4();
   const queue = [];
+  // ws.terminate();
+  ws.on("close", () => {
+    debugger;
+  });
 
   ws.on("message", message => {
     message = JSON.parse(message);


### PR DESCRIPTION
### What:
Implements changes to Notebook.js and server.js to allow server.js to issue a delete request to the proxy server on websocket close event. When the websocket opens, the client communicates the URL of the current session to the server. The server will use this session-specific subdomained URL when it comes time to tear down the container / session. On websocket close, the server issues a delete request to the proxy server. At this time, the proxy server starts a timeout before deleting the session / container. If the user navigates back to their page before the timeout expires (either directly, or by page refresh), the proxy server will not delete the session, or container.

### Why:
Detect closed websocket connections and free up resources on host by spinning down containers.

