### PR TITLE
Revert stdout message strategy

### DIFF
--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -42,11 +42,33 @@ class Notebook extends Component {
         return res.json();
       })
       .then(data => {
-        // TODO: scrub IDs on proxy server before sending to client
         if (data) {
           console.log("Notebook loaded from server: ", data);
-          const { cells, id } = data;
-          this.setState({ cells, id });
+          let { cells, id } = data;
+
+          if (data.webhookData) {
+            const webhookDataCells = data.webhookData.map(
+              (webhookData, idx) => {
+                return {
+                  language: "Javascript",
+                  code: `const webhookData${idx} = ${JSON.stringify(
+                    webhookData,
+                    null,
+                    2
+                  )}`,
+                  results: { stdout: [], error: "", return: "" },
+                  id: uuidv4()
+                };
+              }
+            );
+
+            this.setState(prevState => {
+              const newCells = [...webhookDataCells, ...cells];
+              return { cells: newCells, id };
+            });
+          } else {
+            this.setState({ cells, id });
+          }
         } else {
           console.log("No notebook loaded from server");
         }

--- a/libs/modules/userScript.js
+++ b/libs/modules/userScript.js
@@ -1,14 +1,6 @@
 const fs = require("fs");
 const { exec } = require("child_process"); // exec uses system default shell
 
-const sendTruncatedOutput = (output, ws, language) => {
-  output.forEach(data => {
-    ws.send(JSON.stringify({ language, type: "stdout", data: data }));
-  });
-};
-
-let buffer = [];
-
 const userScript = {
   script: "",
   scriptExecCmd: "",
@@ -78,30 +70,14 @@ const userScript = {
       );
 
       scriptProcess.stdout.on("data", data => {
-        buffer.push(data);
-        setTimeout(() => {
-          const bufferArray = buffer.join("").split("\n");
-
-          if (bufferArray.length > 50) {
-            const truncatedOutput = bufferArray.slice(1, 3);
-
-            scriptProcess.kill();
-            sendTruncatedOutput(truncatedOutput, ws, language);
-            buffer = [];
-            reject();
+        const dataArray = data.split("\n").slice(0, -1);
+        dataArray.forEach(data => {
+          if (data === delimiter) {
+            ws.send(JSON.stringify({ language, type: "delimiter" }));
           } else {
-            bufferArray.forEach(data => {
-              if (data === delimiter) {
-                ws.send(JSON.stringify({ language, type: "delimiter" }));
-              } else {
-                ws.send(
-                  JSON.stringify({ language, type: "stdout", data: data })
-                );
-              }
-              buffer = [];
-            });
+            ws.send(JSON.stringify({ language, type: "stdout", data: data }));
           }
-        }, 1);
+        });
       });
 
       scriptProcess.stdout.on("end", () => {
@@ -161,14 +137,6 @@ const userScript = {
 
     return outputByCell;
   }
-
-  // sendTruncatedOutput: data => {
-  //   truncatedOutput.forEach(data => {
-  //     ws.send(
-  //       JSON.stringify({ language, type: "stdout", data: data })
-  //     );
-  //   });
-  // },
 };
 
 module.exports = userScript;


### PR DESCRIPTION
### What:
When notebook data is loaded into our react state, there's a check for webhook data. If it exists, new JS cells are created from it and inserted at the top of the notebook state's cells array.

Removed custom buffer logic for handling large amounts of stdout. Re-implements previous logic of splitting stdout chunks on \n, and sending each as a WS message of type 'delimiter', or 'stdout'.
### Why:
Unexpected output slotting and bugs.
