### PR TITLE
Add basic support for webhooks

### DIFF
--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -42,11 +42,33 @@ class Notebook extends Component {
         return res.json();
       })
       .then(data => {
-        // TODO: scrub IDs on proxy server before sending to client
         if (data) {
           console.log("Notebook loaded from server: ", data);
-          const { cells, id } = data;
-          this.setState({ cells, id });
+          let { cells, id } = data;
+
+          if (data.webhookData) {
+            const webhookDataCells = data.webhookData.map(
+              (webhookData, idx) => {
+                return {
+                  language: "Javascript",
+                  code: `const webhookData${idx} = ${JSON.stringify(
+                    webhookData,
+                    null,
+                    2
+                  )}`,
+                  results: { stdout: [], error: "", return: "" },
+                  id: uuidv4()
+                };
+              }
+            );
+
+            this.setState(prevState => {
+              const newCells = [...webhookDataCells, ...cells];
+              return { cells: newCells, id };
+            });
+          } else {
+            this.setState({ cells, id });
+          }
         } else {
           console.log("No notebook loaded from server");
         }


### PR DESCRIPTION
Co-authored-by: ‘Will’ <millswilliamrobert@gmail.com>
Co-authored-by: ‘Charles’ <charles.ging@gmail.com>

### What:
- Adds basic front-end support for webhooks by inserting webhook data retrieved from database into new cells in notebook if webhook data exists

### Why:
- To leverage web-based design of redpoint notebooks

### Next Steps:
- Improve UI/UX
- Implement limit to number of webhook data able to be received per notebook (i.e. FIFO max 10)
- Add messaging queue as middleware to buffer against overwhelming the database (back-end)