### PR TITLE
presentation / clean view of notebook

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -135,6 +135,10 @@ div .rendered-markdown {
     margin: 15px 0 15px -150px !important;
   }
 
+  .hidden {
+    visibility: "hidden";
+  }
+
   .navbar-expand,
   .navbar-collapse {
     flex-wrap: wrap !important;

--- a/client/src/Components/Cells/CellsList.jsx
+++ b/client/src/Components/Cells/CellsList.jsx
@@ -16,21 +16,24 @@ const CellsList = props => {
         onUpdateCodeState={props.onUpdateCodeState}
         onRunClick={props.onRunClick}
         languagePending={props.languagePending}
+        presentation={props.presentation}
       />
     );
   });
 
-  cellContainers.push(
-    <div className="add-cell-container" key="add-cell-container">
-      <AddCellButton
-        lastButton="true"
-        key="add-cell-btn"
-        className="add-cell-btn"
-        cellIndex={cellContainers.length}
-        onClick={props.onAddCellClick}
-      />
-    </div>
-  );
+  if (!props.presentation || props.cells.length === 0) {
+    cellContainers.push(
+      <div className="add-cell-container" key="add-cell-container">
+        <AddCellButton
+          lastButton="true"
+          key="add-cell-btn"
+          className="add-cell-btn"
+          cellIndex={cellContainers.length}
+          onClick={props.onAddCellClick}
+        />
+      </div>
+    );
+  }
 
   return cellContainers;
 };

--- a/client/src/Components/Cells/CodeCell.jsx
+++ b/client/src/Components/Cells/CodeCell.jsx
@@ -56,11 +56,16 @@ class CodeCell extends Component {
     return (
       <div>
         <div className="add-cell-container">
-          <AddCellButton
-            className="add-cell-btn"
-            onClick={this.props.onAddClick}
-            cellIndex={this.props.cellIndex}
-          />
+          {this.props.presentation ? (
+            <div className="add-cell-btn"></div>
+          ) : (
+            <AddCellButton
+              className="add-cell-btn"
+              onClick={this.props.onAddClick}
+              cellIndex={this.props.cellIndex}
+              presentation={this.props.presentation}
+            />
+          )}
         </div>
         <CellToolbar
           cellIndex={this.props.cellIndex}
@@ -71,6 +76,7 @@ class CodeCell extends Component {
           onRunClick={this.props.onRunClick}
           cellCodeState={this.state.code}
           languagePending={this.props.languagePending}
+          presentation={this.props.presentation}
         />
         <CodeMirror
           value={this.state.code}

--- a/client/src/Components/Cells/CodeCellContainer.jsx
+++ b/client/src/Components/Cells/CodeCellContainer.jsx
@@ -12,6 +12,7 @@ const CodeCellContainer = props => {
       cellIndex={props.cellIndex}
       onAddClick={props.onAddCellClick}
       onRenderedMarkdownClick={props.toggleRender}
+      presentation={props.presentation}
     />
   ) : (
     <CodeCell
@@ -26,6 +27,7 @@ const CodeCellContainer = props => {
       onUpdateCodeState={props.onUpdateCodeState}
       onRunClick={props.onRunClick}
       languagePending={props.languagePending}
+      presentation={props.presentation}
     />
   );
 };

--- a/client/src/Components/Cells/RenderedMarkdown.jsx
+++ b/client/src/Components/Cells/RenderedMarkdown.jsx
@@ -10,11 +10,15 @@ const RenderedMarkdown = props => {
   return (
     <div>
       <div className="add-cell-container">
-        <AddCellButton
-          className="add-cell-btn"
-          onClick={props.onAddClick}
-          cellIndex={props.cellIndex}
-        />
+        {props.presentation ? (
+          <div className="add-cell-btn"></div>
+        ) : (
+          <AddCellButton
+            className="add-cell-btn"
+            onClick={props.onAddClick}
+            cellIndex={props.cellIndex}
+          />
+        )}
       </div>
       <div onClick={handleRenderedMarkdownClick} className="rendered-markdown">
         <ReactMarkdown source={cell.code} />

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -25,7 +25,7 @@ class Notebook extends Component {
       writeToIndex: 0,
       codePending: false
     },
-
+    presentation: false,
     id: uuidv4()
   };
 
@@ -179,6 +179,12 @@ class Notebook extends Component {
         return cell;
       });
       return { cells: newCells };
+    });
+  };
+
+  handleToggleView = () => {
+    this.setState(prevState => {
+      return { presentation: !prevState.presentation };
     });
   };
 
@@ -386,6 +392,8 @@ class Notebook extends Component {
           onClearAllResults={this.handleClearAllResults}
           onRunAllClick={this.handleRunAllClick}
           onAPISubmit={this.handleAPISubmit}
+          onToggleView={this.handleToggleView}
+          presentation={this.state.presentation}
         />
         <Container className="App-body">
           <CellsList
@@ -397,6 +405,7 @@ class Notebook extends Component {
             toggleRender={this.handleToggleRender}
             onUpdateCodeState={this.handleUpdateCodeState}
             onRunClick={this.handleRunClick}
+            presentation={this.state.presentation}
           />
         </Container>
       </div>

--- a/client/src/Components/Shared/CellToolbar.jsx
+++ b/client/src/Components/Shared/CellToolbar.jsx
@@ -6,6 +6,7 @@ import RunButtonOrSpinner from "./RunButtonOrSpinner";
 const CellToolbar = props => {
   return (
     <div
+      visible={false}
       className={
         props.language === "Markdown" && props.rendered === true
           ? "cell-toolbar-markdown"
@@ -17,7 +18,7 @@ const CellToolbar = props => {
         onLanguageChange={props.onLanguageChange}
         cellIndex={props.cellIndex}
       ></ChangeLanguageDropdown>
-      {props.language !== "Markdown" ? (
+      {props.language !== "Markdown" && !props.presentation ? (
         <RunButtonOrSpinner
           language={props.language}
           onClick={props.onRunClick}
@@ -26,10 +27,12 @@ const CellToolbar = props => {
           languagePending={props.languagePending}
         ></RunButtonOrSpinner>
       ) : null}
-      <DeleteCellButton
-        onClick={props.onDeleteClick}
-        cellIndex={props.cellIndex}
-      />
+      {!props.presentation ? (
+        <DeleteCellButton
+          onClick={props.onDeleteClick}
+          cellIndex={props.cellIndex}
+        />
+      ) : null}
     </div>
   );
 };

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -119,7 +119,8 @@ class NavigationBar extends React.Component {
 
     const notebook = {
       cells: this.props.cells,
-      id: notebookId
+      id: notebookId,
+      presentation: this.props.presentation
     };
 
     notebook.cells = notebook.cells.map(cell => {
@@ -221,6 +222,7 @@ class NavigationBar extends React.Component {
               </NavDropdown>
               <Nav.Link onClick={this.toggleDeleteWarning}>Delete</Nav.Link>
               <Nav.Link onClick={this.handleClearAllResults}>Clear</Nav.Link>
+
               {this.props.awaitingServerResponse() ? (
                 <Spinner
                   className="navbar-spinner"
@@ -231,6 +233,11 @@ class NavigationBar extends React.Component {
               ) : (
                 <Nav.Link onClick={this.props.onRunAllClick}>Run All</Nav.Link>
               )}
+              <Nav.Link onClick={this.props.onToggleView}>
+                {this.props.presentation
+                  ? "Switch to Edit Mode"
+                  : "Switch to Presentation Mode"}
+              </Nav.Link>
             </Nav>
           </Navbar.Collapse>
         </Navbar>

--- a/codeCellScripts/user_script.js
+++ b/codeCellScripts/user_script.js
@@ -1,1 +1,1 @@
-console.log('ehy');
+[1, 2, 3].forEach(n => console.log(n));

--- a/codeCellScripts/user_script.py
+++ b/codeCellScripts/user_script.py
@@ -1,2 +1,1 @@
-for i in range(10):
-	print(i)
+print("This is Python")

--- a/codeCellScripts/user_script.rb
+++ b/codeCellScripts/user_script.rb
@@ -1,1 +1,1 @@
-p 'hi'
+[1, 2, 3].each { |n| puts n }

--- a/libs/modules/repl.js
+++ b/libs/modules/repl.js
@@ -58,9 +58,16 @@ const parseRubyOutput = returnData => {
   return new Promise(resolve => {
     const byOutput = returnData.split("=>");
     const dirtyReturnValue = byOutput[byOutput.length - 1];
-    const indexCleanStops = dirtyReturnValue.indexOf("irb(main):");
-    const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
-    resolve(cleanReturnValue.trim());
+    const returnVal = dirtyReturnValue.split("\n")[0].trim();
+    // .split("\n")[0]
+    // .trim();
+    resolve(returnVal);
+    // debugger;
+    // const dirtyReturnValue = byOutput[byOutput.length - 1];
+    // const indexCleanStops = dirtyReturnValue.indexOf("irb(main):");
+    // const cleanReturnValue = dirtyReturnValue.slice(0, indexCleanStops);
+    // debugger;
+    // resolve(cleanReturnValue.trim());
   });
 };
 


### PR DESCRIPTION
### What:
Adds a boolean 'presentation' flag to Notebook's state. When the notebook is in presentation mode, the page is stripped of buttons that clutter the page which allows a better top to bottom narrative.

### Next Steps:
Currently, the toggle is a button in the nav bar whose text changes based on the current state. Would be improved with an on / off slider with a "Presentation", or "Edit" title next to it

#### Editable View
<img width="1152" alt="Screen Shot 2019-12-05 at 9 59 36 AM" src="https://user-images.githubusercontent.com/29799847/70252138-78cbe780-1746-11ea-8538-6a13ee2a006d.png">

#### Presentation View
<img width="1149" alt="Screen Shot 2019-12-05 at 9 59 25 AM" src="https://user-images.githubusercontent.com/29799847/70252176-8b462100-1746-11ea-854d-15d9cb6436d0.png">
