### PR TITLE
insert default notebook title if empty string saved

### DIFF
--- a/client/src/Components/Cells/TitleForm.jsx
+++ b/client/src/Components/Cells/TitleForm.jsx
@@ -13,7 +13,12 @@ class TitleForm extends Component {
   };
 
   handleSubmitClick = () => {
-    this.props.onTitleSubmit(this.state.title);
+    let title = this.state.title;
+    if (!this.state.title) {
+      this.setState({ title: "My Notebook" });
+      title = "My Notebook";
+    }
+    this.props.onTitleSubmit(title);
   };
 
   componentDidMount = () => {


### PR DESCRIPTION
### What:
Minor update:
In the event the user saves an empty string as the notebook title, there is nothing for them to click should they choose to give the notebook a title at a later time. This update saves a default title of "My Notebook".

Before, user had nothing to click after saving empty title :
<img width="361" alt="before" src="https://user-images.githubusercontent.com/29799847/70855942-97de1e00-1e98-11ea-90ca-af0493f9c737.png">

User has placeholder title so title can be updated : 
<img width="451" alt="after" src="https://user-images.githubusercontent.com/29799847/70855953-be03be00-1e98-11ea-990f-331a61dc6951.png">
