### PR TITLE
Add isClone flag, change default title behavior

### DIFF
--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -196,8 +196,21 @@ class Notebook extends Component {
   handleDeleteAllCells = () => {
     this.setState({
       cells: [],
-      pendingCellIndexes: [],
-      writeToPendingCellIndex: 0
+      Ruby: {
+        pendingIndexes: [],
+        writeToIndex: 0,
+        codePending: false
+      },
+      Javascript: {
+        pendingIndexes: [],
+        writeToIndex: 0,
+        codePending: false
+      },
+      Python: {
+        pendingIndexes: [],
+        writeToIndex: 0,
+        codePending: false
+      }
     });
   };
 

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -379,11 +379,11 @@ class Notebook extends Component {
   };
 
   removeCloneFlag = () => {
-    this.setState({ isCloned: false });
+    this.setState({ isClone: false });
   };
 
-  addCloneFlag = () => {
-    this.setState({ isCloned: true });
+  setNotebookId = id => {
+    this.setState({ id });
   };
 
   render() {

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -48,7 +48,7 @@ class Notebook extends Component {
               return { cells: newCells, ...dataWithoutCells };
             });
           } else {
-            this.setState({ data });
+            this.setState({ ...data });
           }
         }
       })

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -396,9 +396,9 @@ class Notebook extends Component {
           presentation={this.state.presentation}
           title={this.state.title}
           awaitingServerResponse={this.awaitingServerResponse}
-          removeCloneFlag={this.removeCloneFlag}
-          addCloneFlag={this.addCloneFlag}
+          onRemoveCloneFlag={this.removeCloneFlag}
           deleteAllCells={this.handleDeleteAllCells}
+          onSetNotebookId={this.setNotebookId}
           onSaveClick={this.handleSaveOrCloneClick}
           onCloneClick={this.handleSaveOrCloneClick}
           onClearAllResults={this.handleClearAllResults}

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -378,15 +378,26 @@ class Notebook extends Component {
     this.setState({ title });
   };
 
+  removeCloneFlag = () => {
+    this.setState({ isCloned: false });
+  };
+
+  addCloneFlag = () => {
+    this.setState({ isCloned: true });
+  };
+
   render() {
     return (
       <div>
         <NavigationBar
           cells={this.state.cells}
           notebookId={this.state.id}
+          isClone={this.state.isClone}
           presentation={this.state.presentation}
           title={this.state.title}
           awaitingServerResponse={this.awaitingServerResponse}
+          removeCloneFlag={this.removeCloneFlag}
+          addCloneFlag={this.addCloneFlag}
           deleteAllCells={this.handleDeleteAllCells}
           onSaveClick={this.handleSaveOrCloneClick}
           onCloneClick={this.handleSaveOrCloneClick}

--- a/client/src/Components/Notebook.jsx
+++ b/client/src/Components/Notebook.jsx
@@ -25,7 +25,7 @@ class Notebook extends Component {
       .then(data => {
         if (data) {
           console.log("Notebook loaded from server: ", data);
-          let { cells, id } = data;
+          let { cells, ...dataWithoutCells } = data;
 
           if (data.webhookData) {
             const webhookDataCells = data.webhookData.map(
@@ -45,10 +45,10 @@ class Notebook extends Component {
 
             this.setState(prevState => {
               const newCells = [...webhookDataCells, ...cells];
-              return { cells: newCells, id };
+              return { cells: newCells, ...dataWithoutCells };
             });
           } else {
-            this.setState({ cells, id });
+            this.setState({ data });
           }
         }
       })

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -31,7 +31,7 @@ class NavigationBar extends React.Component {
     webhookModalVisible: false,
     notebookURL: null,
     operation: null,
-    titleFormVisible: true
+    titleFormVisible: false
   };
 
   toggleDeleteWarning = () => {
@@ -113,8 +113,8 @@ class NavigationBar extends React.Component {
 
     if (this.props.isClone) {
       notebookId = uuidv4();
-      this.props.setNotebookId(notebookId);
-      this.props.removeCloneFlag();
+      this.props.onSetNotebookId(notebookId);
+      this.props.onRemoveCloneFlag();
     } else {
       notebookId = this.props.notebookId;
     }
@@ -142,7 +142,8 @@ class NavigationBar extends React.Component {
         cells: this.props.cells,
         id: notebookId,
         presentation: this.props.presentation,
-        isClone: operation === "clone"
+        isClone: operation === "clone",
+        title: "Clone of " + this.props.title
       };
 
       notebook.cells = notebook.cells.map(cell => {

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -109,7 +109,11 @@ class NavigationBar extends React.Component {
 
   handleSaveClick = e => {
     e.preventDefault();
-    const notebookId = this.props.notebookId;
+    const notebookId = this.props.isClone ? uuidv4() : this.props.notebookId;
+
+    if (this.props.isClone) {
+      this.props.removeCloneFlag();
+    }
 
     this.handlePersistenceClick("save", notebookId).then(() => {
       this.handleToggleSaveOrCloneForm();
@@ -133,7 +137,8 @@ class NavigationBar extends React.Component {
       const notebook = {
         cells: this.props.cells,
         id: notebookId,
-        presentation: this.props.presentation
+        presentation: this.props.presentation,
+        isClone: operation === "clone"
       };
 
       notebook.cells = notebook.cells.map(cell => {

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -109,10 +109,14 @@ class NavigationBar extends React.Component {
 
   handleSaveClick = e => {
     e.preventDefault();
-    const notebookId = this.props.isClone ? uuidv4() : this.props.notebookId;
+    let notebookId;
 
     if (this.props.isClone) {
+      notebookId = uuidv4();
+      this.props.setNotebookId(notebookId);
       this.props.removeCloneFlag();
+    } else {
+      notebookId = this.props.notebookId;
     }
 
     this.handlePersistenceClick("save", notebookId).then(() => {

--- a/client/src/Components/Shared/NavigationBar.jsx
+++ b/client/src/Components/Shared/NavigationBar.jsx
@@ -119,9 +119,11 @@ class NavigationBar extends React.Component {
       notebookId = this.props.notebookId;
     }
 
-    this.handlePersistenceClick("save", notebookId).then(() => {
-      this.handleToggleSaveOrCloneForm();
-    });
+    this.handlePersistenceClick("save", notebookId, this.props.title).then(
+      () => {
+        this.handleToggleSaveOrCloneForm();
+      }
+    );
   };
 
   handleCloneClick = e => {
@@ -130,20 +132,21 @@ class NavigationBar extends React.Component {
       this.setState({ saveOrCloneModalVisible: false });
     }
     const notebookId = uuidv4();
+    const title = "Clone of " + this.props.title;
 
-    this.handlePersistenceClick("clone", notebookId).then(() => {
+    this.handlePersistenceClick("clone", notebookId, title).then(() => {
       this.handleToggleSaveOrCloneForm();
     });
   };
 
-  handlePersistenceClick = (operation, notebookId) => {
+  handlePersistenceClick = (operation, notebookId, title) => {
     return new Promise((resolve, reject) => {
       const notebook = {
         cells: this.props.cells,
         id: notebookId,
         presentation: this.props.presentation,
         isClone: operation === "clone",
-        title: "Clone of " + this.props.title
+        title
       };
 
       notebook.cells = notebook.cells.map(cell => {

--- a/client/src/Constants/constants.js
+++ b/client/src/Constants/constants.js
@@ -13,7 +13,7 @@ export const DEFAULT_STATE = {
   id: uuidv4(),
   title: "My Notebook",
   presentation: false,
-  isClone: false,
+  isClone: true,
   cells: [
     {
       language: "Markdown",

--- a/client/src/Constants/constants.js
+++ b/client/src/Constants/constants.js
@@ -13,7 +13,7 @@ export const DEFAULT_STATE = {
   id: uuidv4(),
   title: "My Notebook",
   presentation: false,
-  isClone: true,
+  isClone: false,
   cells: [
     {
       language: "Markdown",

--- a/client/src/Constants/constants.js
+++ b/client/src/Constants/constants.js
@@ -13,6 +13,7 @@ export const DEFAULT_STATE = {
   id: uuidv4(),
   title: "",
   presentation: false,
+  isClone: false,
   cells: [
     {
       language: "Markdown",

--- a/client/src/Constants/constants.js
+++ b/client/src/Constants/constants.js
@@ -11,7 +11,7 @@ const domain = window.location.host
 export const PROXY_URL = "https://www." + domain;
 export const DEFAULT_STATE = {
   id: uuidv4(),
-  title: "",
+  title: "My Notebook",
   presentation: false,
   isClone: false,
   cells: [


### PR DESCRIPTION
### What:

- Sets `isCloned` flag on notebook data sent to server on clone
- On loading a cloned notebook and saving, `isCloned` flag is removed and new uuid is generated for that notebook
- Adds 'Clone of' to title for cloned notebook
- Changes `loadNotebook` in `Notebook.jsx` so that `presentation`, `isClone` and `title` are set in React state on loading a notebook
- Updates `handleDeleteAllCells` to fit current state shape
### Why:
Multiple users can change and save a cloned notebook without mutating the original
### Next Steps:

![image](https://user-images.githubusercontent.com/25254258/71090353-d281d800-2170-11ea-9294-80aa758f58c1.png)
